### PR TITLE
Enable Template xlsform updates + additions to schema

### DIFF
--- a/database/migrations/14_create_xlsform_template_sections_table.php.stub
+++ b/database/migrations/14_create_xlsform_template_sections_table.php.stub
@@ -14,6 +14,7 @@ return new class extends Migration {
             $table->string('structure_item')->comment('which schema structure item (group or repeat / root) is this dataset linked to in the form?');
             $table->boolean('is_repeat')->default(false)->comment('Is this dataset linked to a repeat_group structure item?');
             $table->json('schema')->nullable();
+            $table->boolean('is_current')->default(true)->comment('Is this section in the current version of the template? If False, the section used to exist in a previous version, and should remain in the database for historical purposes');
             $table->timestamps();
         });
     }

--- a/database/migrations/4_create_xlsform_versions_table.php.stub
+++ b/database/migrations/4_create_xlsform_versions_table.php.stub
@@ -14,8 +14,6 @@ return new class extends Migration {
             $table->id();
             $table->foreignId('xlsform_id')->constrained('xlsforms');
 
-            $table->string('xlsfile');
-
             $table->string('version');
             $table->string('odk_version');
 

--- a/database/migrations/4_create_xlsform_versions_table.php.stub
+++ b/database/migrations/4_create_xlsform_versions_table.php.stub
@@ -13,7 +13,6 @@ return new class extends Migration {
         Schema::create('xlsform_versions', function (Blueprint $table) {
             $table->id();
             $table->foreignId('xlsform_id')->constrained('xlsforms');
-
             $table->string('version');
             $table->string('odk_version');
 

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
@@ -3,8 +3,13 @@
 namespace Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
 
 use Filament\Actions;
+use Filament\Forms\Get;
 use Filament\Resources\Pages\ViewRecord;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource;
+use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 
 class ViewXlsformTemplate extends ViewRecord
 {
@@ -18,8 +23,38 @@ class ViewXlsformTemplate extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            Actions\Action::make('update_xlsform_template')
+                ->label('Update XLSForm Template')
+                ->icon('heroicon-o-pencil')
+                ->form(XlsformTemplateResource::getCreateFields())
+                ->fillForm(fn() => [
+                    'title' => self::getRecord()->title,
+                ])
+                ->action(function (array $data, XlsformTemplate $record, Get $get) {
+                    $this->processRecord($record);
+                }),
             Actions\EditAction::make(),
             Actions\DeleteAction::make(),
         ];
+    }
+
+    protected function processRecord(XlsformTemplate $record): XlsformTemplate
+    {
+        $odkLinkService = app()->make(OdkLinkService::class);
+
+        $record->owner()->associate(Platform::first());
+        $record->saveQuietly();
+
+        // update form title in xlsfile to match user-given title
+        UpdateXlsformTitleInFile::dispatchSync($record);
+
+        $record->refresh();
+        $record->deployDraft($odkLinkService);
+        $record->getRequiredMedia($odkLinkService);
+
+        // TODO: We need to do the extract section when create and edit
+        $record->extractSections();
+
+        return $record;
     }
 }

--- a/src/Imports/XlsImport.php
+++ b/src/Imports/XlsImport.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Imports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Importable;
+use Maatwebsite\Excel\Concerns\ToCollection;
+use Maatwebsite\Excel\Concerns\WithHeadingRow;
+
+
+// Generic Import to enable reading of XLSForm templates
+class XlsImport implements ToCollection, WithHeadingRow
+{
+    use Importable;
+
+    public function collection(Collection $collection)
+    {
+    }
+}

--- a/src/Models/OdkLink/EntityValue.php
+++ b/src/Models/OdkLink/EntityValue.php
@@ -2,8 +2,11 @@
 
 namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
 
+use App\Models\Translation;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class EntityValue extends Model
 {
@@ -11,13 +14,20 @@ class EntityValue extends Model
 
     protected $guarded = [];
 
-    public function dataset(): BelongsTo
+    public function entity(): BelongsTo
     {
-        return $this->belongsTo(Dataset::class);
+        return $this->belongsTo(Entity::class);
     }
 
     public function odkProject(): BelongsTo
     {
         return $this->belongsTo(OdkProject::class);
     }
+
+    public function translation(): HasOne
+    {
+        return $this->hasOne(Translation::class);
+    }
+
+
 }

--- a/src/Models/OdkLink/Submission.php
+++ b/src/Models/OdkLink/Submission.php
@@ -2,6 +2,7 @@
 
 namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
 
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
@@ -82,6 +83,11 @@ class Submission extends Model implements HasMedia
     public function entities(): HasMany
     {
         return $this->hasMany(Entity::class);
+    }
+
+    public function entityValues(): HasManyThrough
+    {
+        return $this->hasManyThrough(EntityValue::class, Entity::class);
     }
 
 }

--- a/src/Models/OdkLink/Xlsform.php
+++ b/src/Models/OdkLink/Xlsform.php
@@ -28,6 +28,10 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
 
     protected $guarded = [];
 
+    protected $casts = [
+        'schema' => 'collection',
+    ];
+
     protected static function booted(): void
     {
 
@@ -35,7 +39,7 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
         static::saved(static function (Xlsform $xlsform) {
 
             // copy the xlsfile from the template and update the title and id:
-            if (! $xlsform->xlsfile) {
+            if (!$xlsform->xlsfile) {
                 $xlsform->updateXlsfileFromTemplate();
             }
 
@@ -66,21 +70,21 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
     public function xlsformId(): Attribute
     {
         return new Attribute(
-            get: fn (): string => str($this->title)->slug() . '_' . $this->id,
+            get: fn(): string => str($this->title)->slug() . '_' . $this->id,
         );
     }
 
     public function ownedByName(): Attribute
     {
         return new Attribute(
-            get: fn (): string => $this->owner->{$this->getOwnerIdentifierAttributeName()} ?? '',
+            get: fn(): string => $this->owner->{$this->getOwnerIdentifierAttributeName()} ?? '',
         );
     }
 
     public function currentVersion(): Attribute
     {
         return new Attribute(
-            get: fn (): string => $this->xlsformVersions()->latest()->first()?->version ?? '',
+            get: fn(): string => $this->xlsformVersions()->latest()->first()?->version ?? '',
         );
     }
 
@@ -157,7 +161,7 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
 
     public function getOdkLinkAttribute(): ?string
     {
-        $appends = ! $this->is_active ? '/draft' : '';
+        $appends = !$this->is_active ? '/draft' : '';
 
         return config('filament-odk-link.odk.url') . '/#/projects/' . $this->owner->odkProject->id . '/forms/' . $this->odk_id . $appends;
     }

--- a/src/Models/OdkLink/XlsformTemplate.php
+++ b/src/Models/OdkLink/XlsformTemplate.php
@@ -170,7 +170,8 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
     public function extractSections()
     {
 
-        //***  extract structure into 'sections'
+        // set all existing sections to not current.
+        $this->repeatingSections()->each(fn ($section) => $section->is_current = false);
 
 
         // create or find the repeat sections
@@ -180,6 +181,7 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
                     'structure_item' => $item['name'],
                 ], [
                     'is_repeat' => true,
+                    'is_current' => true,
                     'schema' => $this->schema->filter(
                         fn ($subItem) => Str::contains($subItem['path'], $item['path'] . '/')
                         && $subItem['path'] !== $item['path']
@@ -216,7 +218,7 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
             });
         });
 
-        
+
         // find all ODK variable names of all repeating sections
         $repeatingSectionItemNames = [];
 
@@ -234,7 +236,7 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
             'structure_item' => 'root',
         ], [
             'is_repeat' => false,
-            
+            'is_current' => true,
             // to exclude below items:
             // 1. structure type item
             // 2. repeat type item

--- a/src/Models/OdkLink/XlsformTemplateSection.php
+++ b/src/Models/OdkLink/XlsformTemplateSection.php
@@ -15,6 +15,14 @@ class XlsformTemplateSection extends Pivot
         'schema' => 'collection',
     ];
 
+    protected static function booted()
+    {
+        // always sort by is_repeat, then by id
+        static::addGlobalScope('sort', function ($query) {
+            $query->orderBy('is_repeat', 'asc')->orderBy('id', 'asc');
+        });
+    }
+
     public function xlsformTemplate(): BelongsTo
     {
         return $this->belongsTo(XlsformTemplate::class);

--- a/src/Models/OdkLink/XlsformVersion.php
+++ b/src/Models/OdkLink/XlsformVersion.php
@@ -18,7 +18,7 @@ class XlsformVersion extends Model implements HasMedia
     protected $guarded = [];
 
     protected $casts = [
-        'schema' => 'array',
+        'schema' => 'collection',
     ];
 
     public function registerMediaCollections(): void

--- a/src/Models/OdkLink/XlsformVersion.php
+++ b/src/Models/OdkLink/XlsformVersion.php
@@ -21,27 +21,37 @@ class XlsformVersion extends Model implements HasMedia
         'schema' => 'array',
     ];
 
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('xlsform_file')
+            ->singleFile()
+            ->useDisk(config('filament-odk-link.storage.xlsforms'));
+
+        $this->addMediaCollection('attached_media')
+            ->useDisk(config('filament-odk-link.storage.xlsforms'));
+    }
+
     // **************** COMPUTED ATTRIBUTES ***********************
 
     // If no title is given, add a default title by combining the owner name and template title.
     public function title(): Attribute
     {
         return new Attribute(
-            get: fn (): string => $this->team ? $this->team->name . ' - ' . $this->xlsform->title : '',
+            get: fn(): string => $this->team ? $this->team->name . ' - ' . $this->xlsform->title : '',
         );
     }
 
     public function xlsfile(): Attribute
     {
         return new Attribute(
-            get: fn (): string => $this->getFirstMediaPath('xlsform_file'),
+            get: fn(): string => $this->getFirstMediaPath('xlsform_file'),
         );
     }
 
     public function xlsfile_name(): Attribute
     {
         return new Attribute(
-            get: fn (): string => $this->getFirstMedia('xlsform_file')->file_name,
+            get: fn(): string => $this->getFirstMedia('xlsform_file')->file_name,
         );
     }
 

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -403,6 +403,7 @@ class OdkLinkService
         // TODO: update this to work with any default language
         $schema = collect($schema)->map(function (array $item) use ($surveyExcel): array {
             if($row = $surveyExcel->where('name', $item['name'])->first()) {
+                $item['value_type'] = $row['type'];
                 $item['label_english'] = $row['labelenglish'];
                 $item['hint_english'] = $row['hintenglish'];
             }

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\Client\RequestException;
 use Stats4sd\FilamentOdkLink\Exports\SqlViewExport;
+use Stats4sd\FilamentOdkLink\Imports\XlsImport;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Entity;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\AppUser;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
@@ -175,14 +176,7 @@ class OdkLinkService
         if (isset($response['xmlFormId'])) {
             $xlsform->update(['odk_id' => $response['xmlFormId']]);
         }
-
-        // upddate the stored schema with the new draft;
-        $schema = Http::withToken($token)
-            ->get("{$this->endpoint}/projects/{$xlsform->owner->odkProject->id}/forms/{$xlsform->odk_id}/draft/fields?odata=true")
-            ->throw()
-            ->json();
-
-        $xlsform->updateQuietly(['schema' => $schema]);
+        $this->updateSchema($xlsform);
 
         // deploy media files
         $this->uploadMediaFileAttachments($xlsform);
@@ -392,6 +386,33 @@ class OdkLinkService
         }
     }
 
+    // update the schema of a template for xlsform from the latest draft version on ODK Central
+    public function updateSchema(WithXlsFormDrafts $xlsform): void
+    {
+        $token = $this->authenticate();
+
+        // upddate the stored schema with the new draft;
+        $schema = Http::withToken($token)
+            ->get("{$this->endpoint}/projects/{$xlsform->owner->odkProject->id}/forms/{$xlsform->odk_id}/draft/fields?odata=true")
+            ->throw()
+            ->json();
+
+        // get the xlsform and merge in specific details to the schema returned from ODK Central
+        $surveyExcel = (new XlsImport)->toCollection($xlsform->getMedia('xlsform_file')->first()->getPathRelativeToRoot(), config('filament-odk-link.storage.xlsforms'), \Maatwebsite\Excel\Excel::XLSX)[0];
+
+        // TODO: update this to work with any default language
+        $schema = collect($schema)->map(function (array $item) use ($surveyExcel): array {
+            if($row = $surveyExcel->where('name', $item['name'])->first()) {
+                $item['label_english'] = $row['labelenglish'];
+                $item['hint_english'] = $row['hintenglish'];
+            }
+
+            return $item;
+        })->toArray();
+
+        $xlsform->updateQuietly(['schema' => $schema]);
+    }
+
     /**
      * Creates a new csv lookup file from the database;
      */
@@ -466,21 +487,12 @@ class OdkLinkService
         $fileName = collect(explode('/', $xlsform->xlsfile))->last();
         $versionSlug = Str::slug($versionDetails['version']);
 
-        // copy xlsform file to store linked to this version forever
-
-
-        // get schema from ODK Central;
-        $schema = Http::withToken($token)
-            ->get("{$this->endpoint}/projects/{$xlsform->owner->odkProject->id}/forms/{$xlsform->odk_id}/versions/{$versionDetails['version']}/fields?odata=true")
-            ->throw()
-            ->json();
-
         // create new active version with latest version number;
         $xlsformVersion = $xlsform->xlsformVersions()->create([
             'version' => $versionDetails['version'],
             'odk_version' => $versionDetails['version'],
             'active' => true,
-            'schema' => $schema,
+            'schema' => $xlsform->schema,
         ]);
 
         // copy xlsform file to store linked to this version forever
@@ -539,10 +551,9 @@ class OdkLinkService
             // add $entry into array, to retrieve a value from a deeply nested array using "dot" notation
             $rootEntry = ['root' => $entry];
 
-            foreach($sections as $section) {
+            foreach ($sections as $section) {
                 $this->processEntryFromSection($xlsform, $rootEntry, $section, $submission->id);
             }
-
 
 
             // ******** CALL APP-SPECIFIC PROCESSING ******** //


### PR DESCRIPTION
This PR enables the user to update the xlsform template file after creation. 
- Updating the file will automatically update the draft on ODK Central for the template, and use Central to update the XlsformTemplateSections and schema. 

The schema is also updated to add some additional properties beyond that ODK Central returns. Using the xlsform file itself, we now include: 
- label_english (label column)
- hint_english (hint column)
- variable_type (type column)

This should eventually be updated to work with whatver the default language of the form is, not just english.  

This makes it easier to reference the variable labels in different places. 