### PR TITLE
add parent-child relationships for sections, datatsets and entities

### DIFF
--- a/database/migrations/10_create_entities_table.php.stub
+++ b/database/migrations/10_create_entities_table.php.stub
@@ -10,6 +10,7 @@ return new class extends Migration {
         Schema::create('entities', function (Blueprint $table) {
             $table->id();
             $table->foreignId('dataset_id')->constrained('datasets');
+            $table->foreignId('parent_id')->constrained('entities')->cascadeOnDelete()->cascadeOnUpdate();
             $table->nullableMorphs('owner');
             $table->nullableMorphs('model');
             $table->foreignId('submission_id')->constrained('submissions')->cascadeOnDelete()->cascadeOnUpdate();

--- a/database/migrations/14_create_xlsform_template_sections_table.php.stub
+++ b/database/migrations/14_create_xlsform_template_sections_table.php.stub
@@ -11,6 +11,7 @@ return new class extends Migration {
             $table->id();
             $table->foreignId('dataset_id')->nullable()->constrained('datasets')->nullOnDelete()->cascadeOnUpdate();
             $table->foreignId('xlsform_template_id')->constrained('xlsform_templates')->cascadeOnUpdate()->cascadeOnDelete();
+            $table->foreignId('parent_id')->nullable()->constrained('xlsform_template_sections')->nullOnDelete()->cascadeOnUpdate();
             $table->string('structure_item')->comment('which schema structure item (group or repeat / root) is this dataset linked to in the form?');
             $table->boolean('is_repeat')->default(false)->comment('Is this dataset linked to a repeat_group structure item?');
             $table->json('schema')->nullable();

--- a/database/migrations/1_create_datasets_table.php.stub
+++ b/database/migrations/1_create_datasets_table.php.stub
@@ -10,6 +10,7 @@ return new class extends Migration {
         Schema::create('datasets', function (Blueprint $table) {
             $table->id();
             $table->string('name')->unique();
+            $table->foreignId('parent_id')->nullable()->constrained('datasets')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('primary_key');
             $table->text('description')->nullable();
             $table->string('entity_model')->nullable();

--- a/src/Exports/EntityExport.php
+++ b/src/Exports/EntityExport.php
@@ -7,52 +7,50 @@ use Maatwebsite\Excel\Concerns\WithTitle;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\EntityValue;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
 
 class EntityExport implements FromArray, WithTitle, WithHeadings
 {
-    protected $xlsform;
-    protected $title;
-    protected $xlsformTemplateSection;
 
-    public function __construct(Xlsform $xlsform = null, $title = null, $xlsformTemplateSection = null)
+    public function __construct(protected Xlsform $xlsform, protected string $title, protected XlsformTemplateSection $xlsformTemplateSection)
     {
-        $this->xlsform = $xlsform;
-        $this->title = $title;
-        $this->xlsformTemplateSection = $xlsformTemplateSection;
     }
 
     public function array(): array
     {
         $records = [];
+        $dataset = $this->xlsformTemplateSection->dataset;
 
         // for each submission
         foreach ($this->xlsform->submissions as $submission) {
 
             // for entities for a particular dataset
-            $entities = $submission->entities->where('dataset_id', $this->xlsformTemplateSection->dataset_id);
+            $entities = $submission->entities()
+                ->where('dataset_id', $this->xlsformTemplateSection->dataset_id)
+                ->with(['values', 'parent'])
+                ->get();
 
             foreach ($entities as $entity) {
 
                 // initialisation
                 $record = [];
 
-                // find value for each ODK variable
-                foreach ($this->headings() as $heading) {
 
-                    // assume there is only one value for one ODK variable
-                    $entityValue = EntityValue::select('value')->where('entity_id', $entity->id)->where('dataset_variable_id', $heading)->first();
-
-                    if ($entityValue == null) {
-                        array_push($record, null);
-                    } else {
-                        array_push($record, $entityValue->value);
-                    }
-
+                // add parent primary key if there is a parent dataset
+                if ($dataset->parent) {
+                    $record[] = $entity->parent->values->where('dataset_variable_id', $dataset->parent->primary_key)->first()->value;
                 }
 
-                array_push($records, $record);
-            }
+                // find value for each ODK variable
+                foreach ($this->getHeadings() as $heading) {
 
+                    // assume there is only one value for one ODK variable
+                    $entityValue = $entity->values->where('entity_id', $entity->id)->where('dataset_variable_id', $heading)->first();
+
+                    $record[] = $entityValue?->value;
+                }
+                $records[] = $record;
+            }
         }
 
         return $records;
@@ -68,11 +66,23 @@ class EntityExport implements FromArray, WithTitle, WithHeadings
 
     public function headings(): array
     {
+        $headings = $this->getHeadings();
+
+        // add the parent-id heading to the entity-level headings.
+        if($this->xlsformTemplateSection->dataset->parent) {
+            array_unshift($headings, $this->xlsformTemplateSection->dataset->parent->primary_key);
+        }
+
+        return $headings;
+    }
+
+
+    // get the entity-level headings.
+    public function getHeadings(): array
+    {
         // get all column names from schema, exclude structure item as they do not have entity_value record
         $schema = $this->xlsformTemplateSection->schema->where('type', '!=', 'structure');
-        $columnNames = $schema->pluck('name')->toArray();
-
-        return $columnNames;
+        return $schema->pluck('name')->toArray();
     }
 
 }

--- a/src/Filament/Resources/DatasetResource.php
+++ b/src/Filament/Resources/DatasetResource.php
@@ -10,6 +10,7 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
 use Stats4sd\FilamentOdkLink\Filament\Resources\DatasetResource\Pages;
 use Stats4sd\FilamentOdkLink\Filament\Resources\DatasetResource\RelationManagers;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Dataset;
@@ -23,10 +24,10 @@ class DatasetResource extends Resource
     public static function form(Form $form): Form
     {
         return $form
-            ->schema(self::getCreateFormFields());
+            ->schema(fn(Dataset $record) => self::getCreateFormFields($record));
     }
 
-    public static function getCreateFormFields(): array
+    public static function getCreateFormFields($record): array
     {
         return [
             Forms\Components\TextInput::make('name')
@@ -34,10 +35,15 @@ class DatasetResource extends Resource
                 ->unique(ignoreRecord: true),
             Forms\Components\TextInput::make('primary_key')
                 ->hint('If this dataset is being populated by and ODK form, this field should be present in the form.')
-                ->required(),
-            Forms\Components\Textarea::make('description'),
+                ->helperText('ignored for now...')
+                ->default('id'),
+            Forms\Components\Select::make('parent_id')
+                ->relationship('parent', 'name', function (Builder $query) use ($record) {
+                    $query->where('id', '!=', $record->id);
+                }),
         ];
     }
+
 
     public static function table(Table $table): Table
     {

--- a/src/Models/OdkLink/Dataset.php
+++ b/src/Models/OdkLink/Dataset.php
@@ -3,6 +3,7 @@
 namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -12,6 +13,18 @@ class Dataset extends Model
     protected $table = 'datasets';
 
     protected $guarded = [];
+
+    // a dataset might be a subset of another dataset (e.g. data from a repeat group in a form; household members in a household, etc);
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    // a dataset might have many children (e.g. if a form has 3 repeat group sections, the 'main survey' dataset would have 3 child datasets);
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
 
     public function odkDatasets(): HasMany
     {

--- a/src/Models/OdkLink/Entity.php
+++ b/src/Models/OdkLink/Entity.php
@@ -14,6 +14,18 @@ class Entity extends Model
 
     protected $guarded = [];
 
+    // e.g. for an entity created from a repeat group item, the parent entity will be the entity created from the repeat group's parent (the main form or, if it's a nested repeat group, the parent group).
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+
     public function submission(): BelongsTo
     {
         return $this->belongsTo(Submission::class);

--- a/src/Models/OdkLink/XlsformTemplate.php
+++ b/src/Models/OdkLink/XlsformTemplate.php
@@ -232,7 +232,7 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
 
 
         // create or find the 'root' section
-        $this->xlsformTemplateSections()->updateOrCreate([
+        $rootSection = $this->xlsformTemplateSections()->updateOrCreate([
             'structure_item' => 'root',
         ], [
             'is_repeat' => false,
@@ -245,7 +245,11 @@ class XlsformTemplate extends Model implements HasMedia, WithXlsFormDrafts
         ]);
 
 
-        //        dd('ok');
+        // add the root as the parent of the repeating sections
+        // TODO: update to handle nested repeats
+        $this->repeatingSections()->update([
+            'parent_id' => $rootSection->id,
+        ]);
 
         return $this->xlsformTemplateSections;
     }

--- a/src/Models/OdkLink/XlsformTemplateSection.php
+++ b/src/Models/OdkLink/XlsformTemplateSection.php
@@ -3,6 +3,7 @@
 namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
 
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 class XlsformTemplateSection extends Pivot
@@ -21,6 +22,16 @@ class XlsformTemplateSection extends Pivot
         static::addGlobalScope('sort', function ($query) {
             $query->orderBy('is_repeat', 'asc')->orderBy('id', 'asc');
         });
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
     }
 
     public function xlsformTemplate(): BelongsTo

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -402,7 +402,7 @@ class OdkLinkService
 
         // TODO: update this to work with any default language
         $schema = collect($schema)->map(function (array $item) use ($surveyExcel): array {
-            if($row = $surveyExcel->where('name', $item['name'])->first()) {
+            if ($row = $surveyExcel->where('name', $item['name'])->first()) {
                 $item['value_type'] = $row['type'];
                 $item['label_english'] = $row['labelenglish'];
                 $item['hint_english'] = $row['hintenglish'];
@@ -660,6 +660,7 @@ class OdkLinkService
                     $entity = Entity::create([
                         'dataset_id' => $section->dataset->id,
                         'submission_id' => $submissionId,
+                        'parent_id' => Entity::where('submission_id', $submissionId)->where('dataset_id', $section->parent->dataset->id)->first()->id,
                     ]);
 
                     // add polymorphic relationship
@@ -705,66 +706,10 @@ class OdkLinkService
 
     public function exportAsExcelFile(Xlsform $xlsform)
     {
+        ray()->showQueries();
         return Excel::download(new SurveyExport($xlsform), $xlsform->title . '-' . now()->toDateTimeString() . '.xlsx');
+
     }
-
-
-    //
-    //    public function processEntryNOPE(array $entryToStore, array $entry, Collection $schema, array $repeatPath = []): array
-    //    {
-    //        // get reference to correct nested part of the $entryToStore (e.g. if we are inside a repeat, we will want to add keys/values to the current level in the repeat;
-    //
-    //
-    //        if (count($repeatPath) > 0) {
-    //            $ref = &$entryToStore;
-    //            foreach ($repeatPath as $path) {
-    //
-    //                // check if there is already a path to here
-    //                if (!isset($ref[$path])) {
-    //                    $ref[$path] = [];
-    //                }
-    //                $ref = &$ref[$path];
-    //            }
-    //            dump($ref, $repeatPath);
-    //        }
-    //
-    //
-    //        foreach ($entry as $key => $value) {
-    //            $schemaEntry = $schema->firstWhere('name', '=', $key);
-    //
-    //            if (!$schemaEntry) {
-    //                $ref[$key] = $value;
-    //                continue;
-    //            }
-    //
-    //            switch ($schemaEntry['type']) {
-    //                case 'repeat':
-    //
-    //                    $repeatPath[] = $key;
-    //                    $loop = 0;
-    //
-    //                    foreach ($value as $repeatItem) {
-    //                        array_pop($repeatPath);
-    //                        $repeatPath[] = $loop;
-    //                        $ref = $this->processEntry($entryToStore, $repeatItem, $schema, $repeatPath);
-    //
-    //                        $loop++;
-    //                    }
-    //                    break;
-    //
-    //                case 'structure':
-    //                    $ref = $this->processEntry($entryToStore, $value, $schema, $repeatPath);
-    //                    break;
-    //
-    //                default:
-    //                    $ref[$key] = $value;
-    //
-    //                    break;
-    //            }
-    //
-    //        }
-    //        return $entryToStore;
-    //    }
 
 
 }


### PR DESCRIPTION
This PR adds the needed infrastructure to store the parent/child relationships for:

- **XlsformTemplateSections**. (The relationship is automatically determined by the xls form structure; e.g. a repeat group is a child of the main survey.
     - NOTE: we do not yet support nested repeats here!
- **Datasets** (The relationship is specified by the user when creating / managing datasets in the DatasetResource).
- **Entities** (The relationship is automatically determined when extractcing data from submission content).

The export is also updated to include the parent's primary key field for child entity worksheets. (This also means that the 'primary_key' field is now used for datasets).