### PR TITLE
Dataset Variable handling + ODK Handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/contracts": "^10.0|^11.0",
         "maatwebsite/excel": "^3.1",
         "simplesoftwareio/simple-qrcode": "^4.2",
-        "spatie/laravel-medialibrary": "^10.15",
+        "spatie/laravel-medialibrary": "^10.15|^11.4",
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1|^8.2|^8.3",
         "awcodes/filament-table-repeater": "^2.0",
         "filament/filament": "^3.0",
         "filament/spatie-laravel-media-library-plugin": "^3.0",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0|^11.0",
         "maatwebsite/excel": "^3.1",
         "simplesoftwareio/simple-qrcode": "^4.2",
         "spatie/laravel-medialibrary": "^10.15",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     "autoload": {
         "psr-4": {
             "Stats4sd\\FilamentOdkLink\\": "src/",
-            "Stats4sd\\FilamentOdkLink\\Database\\Factories\\": "database/factories/"
+            "Stats4sd\\FilamentOdkLink\\Database\\Factories\\": "database/factories/",
+            "Stats4sd\\FilamentOdkLink\\Database\\Seeders\\": "database/seeders/"
         }
     },
     "autoload-dev": {

--- a/config/filament-odk-link.php
+++ b/config/filament-odk-link.php
@@ -33,7 +33,7 @@ return [
          *
          * If you use a custom installation of ODK Central or Kobotoolbox, it will be the base url to your service.
          */
-        'url' => env('ODK_URL', ''),
+        'url' => env('ODK_URL', null),
         'base_endpoint' => env('ODK_ENDPOINT', env('ODK_URL') . '/v1'),
 
         /**

--- a/config/filament-odk-link.php
+++ b/config/filament-odk-link.php
@@ -36,6 +36,8 @@ return [
         'url' => env('ODK_URL', null),
         'base_endpoint' => env('ODK_ENDPOINT', env('ODK_URL') . '/v1'),
 
+        'platform_project_id' => env('ODK_PLATFORM_PROJECT_ID', null),
+
         /**
          * Username and password for the main platform account
          * The platform requires a 'primary' user account on the ODK Central / KoboToolbox server to manage deployments of ODK forms.

--- a/database/migrations/12_create_dataset_variables_table.php.stub
+++ b/database/migrations/12_create_dataset_variables_table.php.stub
@@ -8,7 +8,7 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('dataset_variables', function (Blueprint $table) {
-            $table->id();
+            $table->string('id')->primary();
             $table->foreignId('dataset_id')->constrained('datasets');
             $table->string('name');
             $table->timestamps();

--- a/database/migrations/12_create_dataset_variables_table.php.stub
+++ b/database/migrations/12_create_dataset_variables_table.php.stub
@@ -8,9 +8,11 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::create('dataset_variables', function (Blueprint $table) {
-            $table->string('id')->primary();
+            $table->id();
             $table->foreignId('dataset_id')->constrained('datasets');
             $table->string('name');
+            $table->string('label');
+            $table->text('description')->nullable();
             $table->timestamps();
 
         });

--- a/database/migrations/13_create_platforms_table.php.stub
+++ b/database/migrations/13_create_platforms_table.php.stub
@@ -13,9 +13,6 @@ return new class extends Migration {
             $table->id();
             $table->timestamps();
         });
-
-        // create single entry to represent the current platform for xlsform_template drafts.
-        Platform::create();
     }
 
 

--- a/database/migrations/1_create_datasets_table.php.stub
+++ b/database/migrations/1_create_datasets_table.php.stub
@@ -17,6 +17,7 @@ return new class extends Migration {
             $table->text('description')->nullable();
             $table->string('entity_model')->nullable();
             $table->boolean('external_file')->default(false)->comment('Should the csv files generated be formatted to be used with "select_one_from_external" ODK fields?');
+            $table->boolean('lookup_table')->default(false)->comment('Is this dataset used as a lookup table for the survey?');
             $table->timestamps();
             $table->softDeletes();
         });

--- a/database/seeders/PlatformSeeder.php
+++ b/database/seeders/PlatformSeeder.php
@@ -14,25 +14,35 @@ class PlatformSeeder extends Seeder
 
     public function run()
     {
+        // check config item existence, and check empty config item
+        if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') == '') {
+            return;
+        }
 
-        // if there is no pre-set platform project ID, create the platform entry with the usual ODK Central project creation.
-        if(config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.platform_project_id') === '') {
+        // check config item existence
+        if (config('filament-odk-link.odk.platform_project_id') === null) {
+            return;
+        }
+
+        // and check empty config item
+        if (config('filament-odk-link.odk.platform_project_id') == '') {
             $platform = Platform::create();
 
             //add the platform's odk-project ID to the env file
             $this->setEnvironmentValue('ODK_PLATFORM_PROJECT_ID', $platform->odkProject->id);
 
-
             return;
         }
 
         // create the platform quietly, then quietly create the odk project entry;
+
+        // Question: If we call forceCreateQuitely(), there is no app_users record for platform model
+
         $platform = Platform::forceCreateQuietly();
         $odkProject = $platform->odkProject()->forceCreateQuietly([
             'id' => config('filament-odk-link.odk.platform_project_id'),
             'name' => config('app.name', 'Laravel Platform') . ' Platform',
         ]);
-
     }
 
     private function setEnvironmentValue($key, $value): void
@@ -47,5 +57,4 @@ class PlatformSeeder extends Seeder
             ));
         }
     }
-
 }

--- a/database/seeders/PlatformSeeder.php
+++ b/database/seeders/PlatformSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
+
+class PlatformSeeder extends Seeder
+{
+
+    // create single entry to represent the current platform for xlsform_template drafts.
+
+    // If there is an .env variable with an existing platform_odk_project ID, then instead of creating a new project on ODK Central, we will use the existing project. This allows for the same project to be used during development, when for example you may be deleting and re-seeding the database multiple times.
+
+    public function run()
+    {
+
+        // if there is no pre-set platform project ID, create the platform entry with the usual ODK Central project creation.
+        if(config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.platform_project_id') === '') {
+            $platform = Platform::create();
+
+            //add the platform's odk-project ID to the env file
+            $this->setEnvironmentValue('ODK_PLATFORM_PROJECT_ID', $platform->odkProject->id);
+
+
+            return;
+        }
+
+        // create the platform quietly, then quietly create the odk project entry;
+        $platform = Platform::forceCreateQuietly();
+        $odkProject = $platform->odkProject()->forceCreateQuietly([
+            'id' => config('filament-odk-link.odk.platform_project_id'),
+            'name' => config('app.name', 'Laravel Platform') . ' Platform',
+        ]);
+
+    }
+
+    private function setEnvironmentValue($key, $value): void
+    {
+        $path = base_path('.env');
+
+        if (file_exists($path)) {
+            file_put_contents($path, str_replace(
+                $key . '=' . env($key),
+                $key . '=' . $value,
+                file_get_contents($path)
+            ));
+        }
+    }
+
+}

--- a/database/seeders/PlatformSeeder.php
+++ b/database/seeders/PlatformSeeder.php
@@ -15,17 +15,12 @@ class PlatformSeeder extends Seeder
     public function run()
     {
         // check config item existence, and check empty config item
-        if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') == '') {
+        if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') === '') {
             return;
         }
 
-        // check config item existence
-        if (config('filament-odk-link.odk.platform_project_id') === null) {
-            return;
-        }
-
-        // and check empty config item
-        if (config('filament-odk-link.odk.platform_project_id') == '') {
+        // check config item existence - if there is no platform project ID, create a new platform and odk project in the 'usual' way.
+        if (config('filament-odk-link.odk.platform_project_id') === null || config('filament-odk-link.odk.platform_project_id') === '') {
             $platform = Platform::create();
 
             //add the platform's odk-project ID to the env file
@@ -35,8 +30,7 @@ class PlatformSeeder extends Seeder
         }
 
         // create the platform quietly, then quietly create the odk project entry;
-
-        // Question: If we call forceCreateQuitely(), there is no app_users record for platform model
+        // no app users are needed, because the 'platform' is not a user-facing entity. No xlsforms will be published to the platform project - it is only for testing drafts of xlsform templates.
 
         $platform = Platform::forceCreateQuietly();
         $odkProject = $platform->odkProject()->forceCreateQuietly([
@@ -45,16 +39,25 @@ class PlatformSeeder extends Seeder
         ]);
     }
 
-    private function setEnvironmentValue($key, $value): void
+    private function setEnvironmentValue(string $key, string $value): void
     {
         $path = base_path('.env');
 
         if (file_exists($path)) {
-            file_put_contents($path, str_replace(
-                $key . '=' . env($key),
-                $key . '=' . $value,
-                file_get_contents($path)
-            ));
+
+            // if the .env file is set but empty, update it.
+            if(str_contains(file_get_contents($path), $key. '=')) {
+                file_put_contents($path, str_replace(
+                    $key . '=' . env($key),
+                    $key . '=' . $value,
+                    file_get_contents($path)
+                ));
+                return;
+            }
+
+            // if the .env file is set but the key is not present, add it.
+            file_put_contents($path, PHP_EOL . $key . '=' . $value, FILE_APPEND);
+
         }
     }
 }

--- a/resources/views/filament/infolists/components/team-qr-code.blade.php
+++ b/resources/views/filament/infolists/components/team-qr-code.blade.php
@@ -1,4 +1,10 @@
+@if($getRecord()->odkProject)
 <div class="p-4">
     {{ QrCode::size(150)->generate($getRecord()->odkProject->appUsers->first()->qr_code_string) }}
         <h5>SCAN QR Code in ODK Collect</h5>
 </div>
+    @else
+    <div class="p-4">
+        <h5 class="text-center text-danger-600">ODK Project not found. Is this platform connected to a value ODK Central server?</h5>
+    </div>
+    @endif

--- a/resources/views/filament/infolists/components/team-qr-code.blade.php
+++ b/resources/views/filament/infolists/components/team-qr-code.blade.php
@@ -1,10 +1,10 @@
 @if($getRecord()->odkProject)
 <div class="p-4">
     {{ QrCode::size(150)->generate($getRecord()->odkProject->appUsers->first()->qr_code_string) }}
-        <h5>SCAN QR Code in ODK Collect</h5>
+    <h5>SCAN QR Code in ODK Collect</h5>
 </div>
-    @else
-    <div class="p-4">
-        <h5 class="text-center text-danger-600">ODK Project not found. Is this platform connected to a value ODK Central server?</h5>
-    </div>
-    @endif
+@else
+<div class="p-4">
+    <h5 class="text-center text-danger-600">ODK Project not found. Is this platform connected to a valid ODK Central server?</h5>
+</div>
+@endif

--- a/resources/views/filament/widgets/odk-url-alert-widget.blade.php
+++ b/resources/views/filament/widgets/odk-url-alert-widget.blade.php
@@ -1,0 +1,9 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        icon="heroicon-o-bell-alert"
+        heading="ALERT"
+
+    >
+        <p>This platform does not have a valid connection to an ODK Central server. You will not be able to upload XlsformTemplates or interact fully with the ODK / XLSform systems here until that is corrected. If you are seeing this on a live site, please contact your technical support with a screenshot of this message.</p>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/ListXlsformTemplates.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/ListXlsformTemplates.php
@@ -5,10 +5,24 @@ namespace Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pa
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource;
+use Stats4sd\FilamentOdkLink\Filament\Widgets\OdkLinkUrlAlert;
+use Stats4sd\FilamentOdkLink\Filament\Widgets\OdkUrlAlertWidget;
 
 class ListXlsformTemplates extends ListRecords
 {
     protected static string $resource = XlsformTemplateResource::class;
+
+    public function getHeaderWidgets(): array
+    {
+        $widgets = [];
+
+        if(config('filament-odk-link.odk.url') === null) {
+
+                $widgets[] = OdkUrlAlertWidget::class;
+        }
+
+        return $widgets;
+    }
 
     protected function getHeaderActions(): array
     {

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/ListXlsformTemplates.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/ListXlsformTemplates.php
@@ -16,9 +16,10 @@ class ListXlsformTemplates extends ListRecords
     {
         $widgets = [];
 
-        if(config('filament-odk-link.odk.url') === null) {
+        // check config item existence, and check empty config item
+        if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') == '') {
 
-                $widgets[] = OdkUrlAlertWidget::class;
+            $widgets[] = OdkUrlAlertWidget::class;
         }
 
         return $widgets;

--- a/src/Filament/Widgets/OdkUrlAlertWidget.php
+++ b/src/Filament/Widgets/OdkUrlAlertWidget.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Widgets;
+
+use Filament\Widgets\Widget;
+
+class OdkUrlAlertWidget extends Widget
+{
+    protected static string $view = 'filament-odk-link::filament.widgets.odk-url-alert-widget';
+
+    protected int | string | array $columnSpan = 'full';
+}

--- a/src/FilamentOdkLinkPanelProvider.php
+++ b/src/FilamentOdkLinkPanelProvider.php
@@ -27,7 +27,8 @@ class FilamentOdkLinkPanelProvider extends PanelProvider
             ->login()
             ->default()
             ->discoverResources(in: __DIR__ . '/Filament/Resources', for: 'Stats4sd\\FilamentOdkLink\\Filament\\Resources')
-            ->discoverPages(in: __DIR__ . './Filament/Pages', for: 'Stats4sd\\FilamentOdkLink\\Filament\\Pages')
+            ->discoverPages(in: __DIR__ . '/Filament/Pages', for: 'Stats4sd\\FilamentOdkLink\\Filament\\Pages')
+            ->discoverWidgets(in: __DIR__ . '/Filament/Widgets', for: 'Stats4sd\\FilamentOdkLink\\Filament\\Widgets')
             ->pages([
                 Dashboard::class,
             ])

--- a/src/FilamentOdkLinkServiceProvider.php
+++ b/src/FilamentOdkLinkServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Stats4sd\FilamentOdkLink;
 
+use Filament\Facades\Filament;
 use Filament\Support\Assets\AlpineComponent;
 use Filament\Support\Assets\Asset;
 use Filament\Support\Assets\Css;
@@ -36,8 +37,7 @@ class FilamentOdkLinkServiceProvider extends PackageServiceProvider
                 $command
                     ->publishConfigFile()
                     ->publishMigrations()
-                    ->askToRunMigrations()
-                    ->askToStarRepoOnGitHub('stats4sd/filament-odk-link');
+                    ->askToRunMigrations();
             });
 
         $configFileName = $package->shortName();
@@ -82,6 +82,11 @@ class FilamentOdkLinkServiceProvider extends PackageServiceProvider
             $this->getScriptData(),
             $this->getAssetPackageName()
         );
+
+        // Widget Registration
+        Filament::registerWidgets([
+
+        ]);
 
         // Icon Registration
         FilamentIcon::register($this->getIcons());

--- a/src/Models/OdkLink/Dataset.php
+++ b/src/Models/OdkLink/Dataset.php
@@ -11,8 +11,6 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 class Dataset extends Model
 {
-    protected $table = 'datasets';
-
 
     // a dataset might be a subset of another dataset (e.g. data from a repeat group in a form; household members in a household, etc);
     public function parent(): BelongsTo

--- a/src/Models/OdkLink/DatasetVariable.php
+++ b/src/Models/OdkLink/DatasetVariable.php
@@ -4,15 +4,33 @@ namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class DatasetVariable extends Model
 {
     protected $table = 'dataset_variables';
 
+    protected $primaryKey = 'id';
+    protected $keyType = 'string';
+    public $incrementing = false;
 
 
     public function dataset(): BelongsTo
     {
         return $this->belongsTo(Dataset::class);
     }
+
+    public function entities(): BelongsToMany
+    {
+        return $this->belongsToMany(Entity::class, 'entity_values')
+            ->using(EntityValue::class)
+            ->withPivot('value');
+    }
+
+    public function values(): HasMany
+    {
+        return $this->hasMany(EntityValue::class, 'entity_id');
+    }
+
 }

--- a/src/Models/OdkLink/DatasetVariable.php
+++ b/src/Models/OdkLink/DatasetVariable.php
@@ -12,9 +12,6 @@ class DatasetVariable extends Model
     protected $table = 'dataset_variables';
 
     protected $primaryKey = 'id';
-    protected $keyType = 'string';
-    public $incrementing = false;
-
 
     public function dataset(): BelongsTo
     {

--- a/src/Models/OdkLink/Traits/HasXlsForms.php
+++ b/src/Models/OdkLink/Traits/HasXlsForms.php
@@ -21,6 +21,12 @@ trait HasXlsForms
 
         // when the model is created; automatically create an associated project on ODK Central;
         static::created(static function ($owner) use ($odkLinkService) {
+
+            // check if we are in local-only (no-ODK link) mode
+            if(config('filament-odk-link.odk.url') === null) {
+                return;
+            }
+
             $owner->createLinkedOdkProject($odkLinkService, $owner);
         });
     }

--- a/src/Models/OdkLink/Traits/HasXlsForms.php
+++ b/src/Models/OdkLink/Traits/HasXlsForms.php
@@ -17,13 +17,18 @@ trait HasXlsForms
     {
         parent::booted();
 
+        // check if we are in local-only (no-ODK link) mode
+        if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') == '') {
+            return;
+        }
+
         $odkLinkService = app()->make(OdkLinkService::class);
 
         // when the model is created; automatically create an associated project on ODK Central;
         static::created(static function ($owner) use ($odkLinkService) {
 
             // check if we are in local-only (no-ODK link) mode
-            if(config('filament-odk-link.odk.url') === null) {
+            if (config('filament-odk-link.odk.url') === null || config('filament-odk-link.odk.url') == '') {
                 return;
             }
 


### PR DESCRIPTION
This PR does 2 things:

### Updates basic support for 'dataset variables': 

 - `DatasetVariable::class` now has the correct relationships to `Entity::class` and `Dataset::class`. (This is used in the tape-data-system to allow us to update the variables for the Agricultural Systems).
 
### Adds better handling of link to ODK / errors

- Previously, you would get errors for lots of things (including running migrations!) if you had not added valid ODK_ environment variables to a real ODK Central server. 
- Now, you can install the package just fine and run the app without connecting to ODK Central. When there are no env credentials:
   - The XlsformTemplateResource  shows a warning notice explaining that you cannot upload forms.
   - Creation of entities that use HasXlsforms (e.g., Teams, platforms), do not trigger an attempt to create a project on ODK Central. 

Additionally, there is now a better approach to creating the required Platform::class entry: 

- previously, this was done in the migration. 
- This is now moved to a separate seeder (following good practice to only use migrations for structural database changes). This seeder should be run as part of the main application seeding (e.g: 

`database/seeders/DatabaseSeeder.php`:  

```php

use Illuminate\Database\Seeder;
use Stats4sd\FilamentOdkLink\Database\Seeders\PlatformSeeder;

class DatabaseSeeder extends Seeder
{

    public function run(): void
    {
         $this->call(PlatformSDeeder::class);
    }

}


```

This seeder will create the Platform::class entry. If there is no ODK_PLATFORM_PROJECT_ID env variable, it will take the normal approach, which includes going to ODK Central and creating a new project. It will then set the ODK_PLATFORM_PROJECT_ID to that project ID. 

When you run the seeder a second time, it will check that same variable, and will not create a 2nd project on ODK Central. It will instead link the new platform entry to the existing project. 

This saves the creation of multiple copies of test projects as you run `php artisan migrate:fresh` lots of times in local development. 


