### PR TITLE
Add submission poll command and job

### DIFF
--- a/src/Commands/PollForOdkData.php
+++ b/src/Commands/PollForOdkData.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Commands;
+
+use Illuminate\Console\Command;
+use Stats4sd\FilamentOdkLink\Jobs\PullSubmissionsFromXlsform;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
+
+class PollForOdkData extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:poll-for-odk-data';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Checks all active xlsforms for new submissions and downloads them to the database.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $xlsforms = Xlsform::where('is_active', true)->get()
+            ->each(function (Xlsform $xlsform) {
+                $this->info("Processing {$xlsform->title}...");
+                PullSubmissionsFromXlsform::dispatch($xlsform);
+            });
+    }
+
+}

--- a/src/FilamentOdkLinkServiceProvider.php
+++ b/src/FilamentOdkLinkServiceProvider.php
@@ -15,6 +15,7 @@ use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Stats4sd\FilamentOdkLink\Commands\FilamentOdkLinkCommand;
+use Stats4sd\FilamentOdkLink\Commands\PollForOdkData;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 use Stats4sd\FilamentOdkLink\Testing\TestsFilamentOdkLink;
 
@@ -128,6 +129,7 @@ class FilamentOdkLinkServiceProvider extends PackageServiceProvider
     {
         return [
             FilamentOdkLinkCommand::class,
+            PollForOdkData::class,
         ];
     }
 

--- a/src/Jobs/PullSubmissionsFromXlsform.php
+++ b/src/Jobs/PullSubmissionsFromXlsform.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+
+class PullSubmissionsFromXlsform implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(public Xlsform $xlsform)
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $odkLinkService = app()->make(OdkLinkService::class);
+
+        $odkLinkService->getSubmissions($this->xlsform);
+    }
+}


### PR DESCRIPTION
We needed a job + command to automatically get submissions for the TAPE survey field test, so I added it to the package. 

I put it on a separate branch to highlight the change and make sure it fits in with the broader submission handling being worked on. 

@dan-tang-ssd  - can you take a look at this to make sure it's not duplicating parts you're working on? If it works, we can merge this into the main "datasets-with-models" branch that you're working on. 
