### PR TITLE
Add small command to manually generate csv files:

### DIFF
--- a/src/Commands/TestCsvMediaGeneration.php
+++ b/src/Commands/TestCsvMediaGeneration.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Commands;
+
+use Illuminate\Console\Command;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+
+class TestCsvMediaGeneration extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:test-csv-media-generation';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Manually create a csv file required for a given Xlsform to check if the output format is correct based on the ODK form';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $xlsforms = Xlsform::all()
+            ->pluck('title', 'id')
+            ->toArray();
+
+        $xlsformTitle = $this->choice('Which Xlsform would you like to generate the csv for?', $xlsforms);
+
+        $xlsform = Xlsform::firstWhere('title', $xlsformTitle);
+
+        $mediaName = $this->choice('Which media collection would you like to generate the csv for?', $xlsform->requiredMedia()->pluck('name')->toArray());
+
+        $media = $xlsform->requiredMedia()->where('name', $mediaName)->first();
+
+        if ($media) {
+            $csv = app()->make(OdkLinkService::class)
+                ->createCsvLookupFile($xlsform, $media);
+
+        }
+
+        $this->info('Csv file created at ' . $csv);
+
+
+    }
+}

--- a/src/FilamentOdkLinkServiceProvider.php
+++ b/src/FilamentOdkLinkServiceProvider.php
@@ -16,6 +16,7 @@ use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Stats4sd\FilamentOdkLink\Commands\FilamentOdkLinkCommand;
 use Stats4sd\FilamentOdkLink\Commands\PollForOdkData;
+use Stats4sd\FilamentOdkLink\Commands\TestCsvMediaGeneration;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 use Stats4sd\FilamentOdkLink\Testing\TestsFilamentOdkLink;
 
@@ -130,6 +131,7 @@ class FilamentOdkLinkServiceProvider extends PackageServiceProvider
         return [
             FilamentOdkLinkCommand::class,
             PollForOdkData::class,
+            TestCsvMediaGeneration::class,
         ];
     }
 

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -485,7 +485,7 @@ class OdkLinkService
     /**
      * Creates a new csv lookup file from the database;
      */
-    private function createCsvLookupFile(WithXlsFormDrafts $xlsform, RequiredMedia $requiredMedia): string
+    public function createCsvLookupFile(WithXlsFormDrafts $xlsform, RequiredMedia $requiredMedia): string
     {
         $dataset = $requiredMedia->dataset;
 


### PR DESCRIPTION
This is useful for testing that a CSV file generated from an app Data Model is in the expected format to work with an ODK form without needing to deploy the full form and review it.

