### PR TITLE
Handle GPS

### DIFF
--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -612,6 +612,11 @@ class OdkLinkService
             if ($class && $method) {
                 $class::$method($submission);
             }
+
+            //££
+            // Add temporary code to retrieve one submission only
+            break;
+            //££
         }
 
         return $resultsToAdd->count();
@@ -732,36 +737,30 @@ class OdkLinkService
             // initialise data array
             $dataArray = [];
 
-            // Link the new data model to the current submission
-            $dataArray['submission_id'] = $submissionId;
+            // // Link the new data model to the current submission
+            // $dataArray['submission_id'] = $submissionId;
 
             // access the value of each ODK variable from a deeply nested array using "dot" notation
             foreach ($schema as $schemaItem) {
                 $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
                 $value = Arr::get($entry, $itemPath);
 
-                // handle GPS data
-                // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
-                if ($schemaItem['type'] === 'geopoint') {
-                    if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
-                        $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
-                    }
-
-                    if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
-                        $dataArray[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
-                    }
-
-                    if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
-                        $dataArray[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
-                    }
-
-                    if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
-                        $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
-                    }
-                } elseif ($class && in_array($schemaItem['name'], $columnNames)) {
+                if ($class && in_array($schemaItem['name'], $columnNames)) {
                     $dataArray[$schemaItem['name']] = $value;
                 }
             }
+
+            // Link the new data model to the current submission
+            $dataArray['submission_id'] = $submissionId;
+
+            $newDataArray = $this->prepareDataArray($section->is_repeat, $entry, $schema, $class, $columnNames, $submissionId);
+            $newDataArray['submission_id'] = $submissionId;
+
+            logger('$dataArray');
+            logger($dataArray);
+
+            logger('$newDataArray');
+            logger($newDataArray);
 
             // delete previously stored records in this table (if any)
             $class::where('submission_id', $dataArray['submission_id'])->delete();
@@ -769,6 +768,34 @@ class OdkLinkService
             // create a new database record
             $class::create($dataArray);
         }
+    }
+
+
+    private function prepareDataArray($isRepeat, $entry, $schema, $class, $columnNames, $submissionId)
+    {
+        // initialise array
+        $result = [];
+
+        // add submission Id to array
+        $result['submission_id'] = $submissionId;
+
+        // extract values from main survey to array
+        if ($isRepeat === 0) {
+            // access the value of each ODK variable from a deeply nested array using "dot" notation
+            foreach ($schema as $schemaItem) {
+                $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
+                $value = Arr::get($entry, $itemPath);
+
+                if ($class && in_array($schemaItem['name'], $columnNames)) {
+                    $result[$schemaItem['name']] = $value;
+                }
+            }
+
+            // extract values from repeat group to array
+        } else {
+        }
+
+        return $result;
     }
 
 
@@ -895,7 +922,7 @@ class OdkLinkService
                         $dataArray['submission_id'] = $submissionId;
 
                         // find the parent (if exists)
-                        if($parentDataset = $section->dataset?->parent) {
+                        if ($parentDataset = $section->dataset?->parent) {
                             $parentClass = $section->dataset?->entity_model;
                         }
 
@@ -916,27 +943,7 @@ class OdkLinkService
                             $value = Arr::get($repeatGroupEntry, $fullItemPath);
                             // dump($schemaItem['name'] . ' : ' . $value);
 
-                            // handle GPS data
-                            // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
-
-                            if ($schemaItem['type'] === 'geopoint') {
-                                if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
-                                    $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
-                                }
-
-                                if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
-                                    $dataArray[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
-                                }
-
-                                if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
-                                    $dataArray[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
-                                }
-
-                                if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
-                                    $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
-                                }
-                            }
-                            elseif (in_array($schemaItem['name'], $columnNames)) {
+                            if (in_array($schemaItem['name'], $columnNames)) {
                                 $dataArray[$schemaItem['name']] = $value;
                             }
                         }

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -919,9 +919,6 @@ class OdkLinkService
                             // handle GPS data
                             // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
 
-                            $valueType = $this->getValueType($schemaItem, )
-
-
                             if ($schemaItem['type'] === 'geopoint') {
                                 if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
                                     $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -758,10 +758,7 @@ class OdkLinkService
                     if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
                         $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
                     }
-                }
-
-
-                if ($class && in_array($schemaItem['name'], $columnNames)) {
+                } elseif ($class && in_array($schemaItem['name'], $columnNames)) {
                     $dataArray[$schemaItem['name']] = $value;
                 }
             }
@@ -921,6 +918,10 @@ class OdkLinkService
 
                             // handle GPS data
                             // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
+
+                            $valueType = $this->getValueType($schemaItem, )
+
+
                             if ($schemaItem['type'] === 'geopoint') {
                                 if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
                                     $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
@@ -938,8 +939,7 @@ class OdkLinkService
                                     $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
                                 }
                             }
-
-                            if (in_array($schemaItem['name'], $columnNames)) {
+                            elseif (in_array($schemaItem['name'], $columnNames)) {
                                 $dataArray[$schemaItem['name']] = $value;
                             }
                         }

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -573,7 +573,7 @@ class OdkLinkService
             ->json();
 
         // only process new submissions
-        $resultsToAdd = Collect($results['value'])->whereNotIn('__id', $xlsform->submissions->pluck('odk_id')->toArray());
+        $resultsToAdd = Collect($results['value'])->whereNotIn('__id', $xlsform->submissions()->withTrashed('soft_deletes')->pluck('odk_id')->toArray());
 
         foreach ($resultsToAdd as $entry) {
 

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -737,9 +737,9 @@ class OdkLinkService
             $class::where('submission_id', $submissionId)->delete();
 
             // get data array from main survey
-            $dataArray = $this->prepareDataArray($entry, $section, $schema, $model, $submissionId);
-            logger($dataArray);
-            logger('***** ' . $dataArray['farm_id']);
+            $dataArray = $this->prepareDataArray($xlsform, $entry, $section, $schema, $model, $submissionId);
+            // logger($dataArray);
+            // logger('***** ' . $dataArray['farm_id']);
 
             // create a new database record
             $class::create($dataArray);
@@ -748,7 +748,7 @@ class OdkLinkService
 
 
     // a generic function to extract values from main survey and repeat group entry, returns an array for further processing
-    private function prepareDataArray($entry, $section, $schema, $model, $submissionId): array
+    private function prepareDataArray($xlsform, $entry, $section, $schema, $model, $submissionId): array
     {
         // initialise array
         $result = [];
@@ -761,24 +761,24 @@ class OdkLinkService
 
         // get all foreign key details of a table
         $foreignKeyDetails = Schema::getForeignKeys($model->getTable());
-        logger('table: ' . $model->getTable());
+        // logger('table: ' . $model->getTable());
 
-        logger('$foreignKeyDetails: ');
-        logger($foreignKeyDetails);
+        // logger('$foreignKeyDetails: ');
+        // logger($foreignKeyDetails);
 
         // store foreign key column name and foreign key table name in associative array
         // TODO: find Laravel array helper function to do the same in a simpler way
         $foreignKeyColumnNames = [];
         foreach ($foreignKeyDetails as $foreignKey) {
             foreach ($foreignKey['columns'] as $foreignKeyColumn) {
-                logger('foreign_key_column_name: ' . $foreignKeyColumn);
+                // logger('foreign_key_column_name: ' . $foreignKeyColumn);
                 $foreignKeyColumnNames[$foreignKeyColumn] = $foreignKey['foreign_table'];
             }
-            logger('foreign_table: ' . $foreignKey['foreign_table']);
+            // logger('foreign_table: ' . $foreignKey['foreign_table']);
         }
 
-        logger('$foreignKeyColumnNames: ');
-        logger($foreignKeyColumnNames);
+        // logger('$foreignKeyColumnNames: ');
+        // logger($foreignKeyColumnNames);
 
 
 
@@ -807,7 +807,7 @@ class OdkLinkService
             }
 
 
-            // special handling for ODK attribute serves as foreign key, and new record need to be created in foreign key table
+            // special handling for ODK attribute that serves as foreign key, and create new record in foreign key table
             if ($value == -99 && array_key_exists($schemaItem['name'], $foreignKeyColumnNames)) {
 
                 // find foreign key's table name
@@ -816,19 +816,19 @@ class OdkLinkService
                 // try to find the corresponding model by table name
                 $model = HelperService::getModelByTablename($foreignKeyTableName);
 
-                if ($model == null) {
-                    logger('Cannot find related model for this database table');
-                } else {
-                    logger('Found related model for this database table');
+                if ($model != null) {
+                    // logger('Found related model for this database table');
+                    // logger('foreign key column name: ' . $schemaItem['name']);
+                    // logger('$foreignKeyTableName: ' . $foreignKeyTableName);
 
-                    logger('foreign key column name: ' . $schemaItem['name']);
-                    logger('$foreignKeyTableName: ' . $foreignKeyTableName);
-
-                    $foreignKeyTableDataArray = $this->prepareForeignKeyTableDataArray($schemaItem['name']);
-                    logger($foreignKeyTableDataArray);
+                    $foreignKeyTableDataArray = $this->prepareForeignKeyTableDataArray($entry, $schemaItem['name']);
+                    // logger($foreignKeyTableDataArray);
 
                     $newRecord = $model::create($foreignKeyTableDataArray);
-                    logger($newRecord);
+                    // logger($newRecord);
+
+                    // add xlsform's owner as farm's owner
+                    $newRecord->owner()->associate($xlsform->owner)->save();
 
                     // set foreign key table new record id to foreign key column in this table
                     $result[$schemaItem['name']] = $newRecord->id;
@@ -854,16 +854,40 @@ class OdkLinkService
 
     // a function to prepare data array for creating a new record in foreign key table
     // P.S. It is not appropriate to have application specific code in this package, need to find
-    // a way to move this to main application in later time
-    private function prepareForeignKeyTableDataArray($foreignKeyName): array
+    // a way to move this to main application in later time.
+    // E.g. subclass to overload superclass's function, or use interface
+    private function prepareForeignKeyTableDataArray($entry, $foreignKeyName): array
     {
-        logger('OdkLinkService.prepareForeignKeyTableDataArray()');
+        // logger('OdkLinkService.prepareForeignKeyTableDataArray()');
 
         $result = [];
 
         switch ($foreignKeyName) {
             case 'farm_id':
-                $result = ['location_id' => 1, 'team_code' => 'C10001'];
+                // get required information from submission entry directly
+
+                // Question: any idea to avoid adding extra double quote character in JSON content...?
+                $respondentName = Arr::get($entry, 'root.farm_info.respondent_name');
+                $identifiers = ['name' => $respondentName];
+                $result['identifiers'] = json_encode($identifiers);
+                // logger($result['identifiers']);
+
+                $result['location_id'] = Arr::get($entry, 'root.reg.final_location_id');
+                // logger($result['location_id']);
+
+                $result['latitude'] = Arr::get($entry, 'root.farm_info.gps_loc.coordinates')[0];
+                // logger($result['latitude']);
+
+                $result['longitude'] = Arr::get($entry, 'root.farm_info.gps_loc.coordinates')[1];
+                // logger($result['longitude']);
+
+                $result['altitude'] = Arr::get($entry, 'root.farm_info.gps_loc.coordinates')[2];
+                // logger($result['altitude']);
+
+                // prefix C for comparison farm, append timestamp in millsecond, hopefully it would be good enough to avoid duplication
+                $result['team_code'] = 'C' . Carbon::now()->getTimestampMs();
+                // logger($result['team_code']);
+
                 break;
 
             default:
@@ -879,22 +903,23 @@ class OdkLinkService
         $result = [];
 
         // handle GPS data
-        // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
+        // We expect the data model to have columns for latitude, longitude, altitude and accuracy
+        // P.S. It would be more intuitive and generic to directly use column names latitude, longitude, altitude and accuracy
         if ($value != null) {
-            if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
-                $result[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
+            if (in_array('latitude', $columnNames, true)) {
+                $result['latitude'] = $value['coordinates'][0];
             }
 
-            if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
-                $result[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
+            if (in_array('longitude', $columnNames, true)) {
+                $result['longitude'] = $value['coordinates'][1];
             }
 
-            if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
-                $result[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
+            if (in_array('altitude', $columnNames, true)) {
+                $result['altitude'] = $value['coordinates'][2];
             }
 
-            if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
-                $result[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
+            if (in_array('accuracy', $columnNames, true)) {
+                $result['accuracy'] = $value['properties']['accuracy'];
             }
         }
 
@@ -1027,7 +1052,7 @@ class OdkLinkService
                     $repeatGroupEntry = ['rg' => $repeatGroupRecord];
 
                     // get data array from repeat group entry
-                    $dataArray = $this->prepareDataArray($repeatGroupEntry, $section, $schema, $model, $submissionId);
+                    $dataArray = $this->prepareDataArray($xlsform, $repeatGroupEntry, $section, $schema, $model, $submissionId);
 
                     // create a new database record
                     $class::create($dataArray);

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -2,29 +2,31 @@
 
 namespace Stats4sd\FilamentOdkLink\Services;
 
-use App\Models\SurveyData\SimpleFormMain;
 use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
 use Maatwebsite\Excel\Facades\Excel;
-use Stats4sd\FilamentOdkLink\Exports\DatasetModelsExport;
-use Stats4sd\FilamentOdkLink\Exports\SurveyExport;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use App\Models\SurveyData\SimpleFormMain;
+use App\Services\HelperService;
+use Illuminate\Http\Client\RequestException;
 use Stats4sd\FilamentOdkLink\Imports\XlsImport;
+use Stats4sd\FilamentOdkLink\Exports\SurveyExport;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Entity;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\EntityValue;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsFormDrafts;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\OdkProject;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\OdkProject;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\EntityValue;
+use Stats4sd\FilamentOdkLink\Exports\DatasetModelsExport;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformVersion;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsFormDrafts;
 
 /**
  * All ODK Aggregation services should be able to handle ODK forms, so this interface should always be used.
@@ -615,7 +617,7 @@ class OdkLinkService
 
             //££
             // Add temporary code to retrieve one submission only
-            // break;
+            break;
             //££
         }
 
@@ -754,6 +756,65 @@ class OdkLinkService
 
         // get all column names of a table
         $columnNames = Schema::getColumnListing($model->getTable());
+
+        // $foreignKeyDetails = Schema::getForeignKeys($model->getTable());
+        // logger('table: ' . $model->getTable());
+
+        // hardcode temporary for testing
+        $foreignKeyDetails = Schema::getForeignKeys('xlsform_template_sections');
+        logger('table: ' . 'xlsform_template_sections');
+
+        logger('$foreignKeyDetails: ');
+        logger($foreignKeyDetails);
+
+        // TODO: find Laravel array helper function to do the same in a simpler way
+        // use associative array, column name => foreign key table name
+        $foreignKeyColumnNames = [];
+        foreach ($foreignKeyDetails as $foreignKey) {
+            foreach ($foreignKey['columns'] as $foreignKeyColumn) {
+                logger('foreign_key_column_name: ' . $foreignKeyColumn);
+                // array_push($foreignKeyColumnNames, $foreignKeyColumn);
+
+                $foreignKeyColumnNames[$foreignKeyColumn] = $foreignKey['foreign_table'];
+            }
+            logger('foreign_table: ' . $foreignKey['foreign_table']);
+        }
+
+        logger('$foreignKeyColumnNames: ');
+        logger($foreignKeyColumnNames);
+
+        $attributeName = 'parent_id';
+
+        if (array_key_exists($attributeName, $foreignKeyColumnNames)) {
+            // find foreign key's table name
+            // $foreignKeyTableName = $foreignKeyColumnNames[$attributeName];
+
+            // hardcode temporary for testing
+            $foreignKeyTableName = 'users';
+
+
+            $model = HelperService::getModelByTablename($foreignKeyTableName);
+
+            if ($model == null) {
+                logger('Cannot find related model for this database table');
+            } else {
+                logger('Found related model for this database table');
+
+                logger('$attributeName: ' . $attributeName);
+                logger('$foreignKeyTableName: ' . $foreignKeyTableName);
+
+                // get foreign key table columns
+                $foreignKeyTableColumnNames = Schema::getColumnListing($foreignKeyTableName);
+
+                // get values to create a new record in foreign key table
+                $foreignKeyTableDataArray = ['name' => 'Testing', 'email' => 'testing@example.com', 'password' => '12345678'];
+
+                $record = $model::create($foreignKeyTableDataArray);
+            }
+
+            // set foreign key table new record id to foreign key column in this table
+        }
+
 
         // access the value of each ODK variable from a deeply nested array using "dot" notation
         foreach ($schema as $schemaItem) {

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -615,7 +615,7 @@ class OdkLinkService
 
             //££
             // Add temporary code to retrieve one submission only
-            break;
+            // break;
             //££
         }
 
@@ -735,7 +735,7 @@ class OdkLinkService
             $class::where('submission_id', $submissionId)->delete();
 
             // get data array from main survey
-            $dataArray = $this->prepareDataArray($entry, $section, $schema, $class, $model, $submissionId);
+            $dataArray = $this->prepareDataArray($entry, $section, $schema, $model, $submissionId);
 
             // create a new database record
             $class::create($dataArray);
@@ -743,8 +743,8 @@ class OdkLinkService
     }
 
 
-    // a generalised function to extract values from main survey and repeat group entry, returns an array for further processing
-    private function prepareDataArray($entry, $section, $schema, $class, $model, $submissionId): array
+    // a generic function to extract values from main survey and repeat group entry, returns an array for further processing
+    private function prepareDataArray($entry, $section, $schema, $model, $submissionId): array
     {
         // initialise array
         $result = [];
@@ -755,23 +755,16 @@ class OdkLinkService
         // get all column names of a table
         $columnNames = Schema::getColumnListing($model->getTable());
 
-        // extract values from main survey to array
-        if ($section->is_repeat == 0) {
+        // access the value of each ODK variable from a deeply nested array using "dot" notation
+        foreach ($schema as $schemaItem) {
 
-            // access the value of each ODK variable from a deeply nested array using "dot" notation
-            foreach ($schema as $schemaItem) {
+            // extract value from main survey
+            if ($section->is_repeat == 0) {
                 $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
                 $value = Arr::get($entry, $itemPath);
 
-                if ($class && in_array($schemaItem['name'], $columnNames)) {
-                    $result[$schemaItem['name']] = $value;
-                }
-            }
-
-            // extract values from repeat group to array
-        } else {
-
-            foreach ($schema as $schemaItem) {
+                // extract value from repeat group
+            } else {
                 $pathLength = Str::length($schemaItem['path']);
                 $position = Str::position($schemaItem['path'], $section->structure_item);
                 $lengthToCut = $pathLength - $position;
@@ -784,10 +777,43 @@ class OdkLinkService
 
                 $value = Arr::get($entry, $fullItemPath);
                 // dump($schemaItem['name'] . ' : ' . $value);
+            }
 
-                if (in_array($schemaItem['name'], $columnNames)) {
-                    $result[$schemaItem['name']] = $value;
-                }
+            // handle different kind of data value
+            if ($schemaItem['type'] === 'geopoint') {
+                $gpsData = $this->extractGpsData($schemaItem, $columnNames, $value);
+                $result = array_merge($result, $gpsData);
+            } elseif (in_array($schemaItem['name'], $columnNames)) {
+                $result[$schemaItem['name']] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+
+    // a generic function to extract GPS data, returns an array
+    private function extractGpsData($schemaItem, $columnNames, $value): array
+    {
+        $result = [];
+
+        // handle GPS data
+        // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
+        if ($value != null) {
+            if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
+                $result[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
+            }
+
+            if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
+                $result[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
+            }
+
+            if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
+                $result[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
+            }
+
+            if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
+                $result[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
             }
         }
 
@@ -920,7 +946,7 @@ class OdkLinkService
                     $repeatGroupEntry = ['rg' => $repeatGroupRecord];
 
                     // get data array from repeat group entry
-                    $dataArray = $this->prepareDataArray($repeatGroupEntry, $section, $schema, $class, $model, $submissionId);
+                    $dataArray = $this->prepareDataArray($repeatGroupEntry, $section, $schema, $model, $submissionId);
 
                     // create a new database record
                     $class::create($dataArray);

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -737,8 +737,8 @@ class OdkLinkService
             // initialise data array
             $dataArray = [];
 
-            // // Link the new data model to the current submission
-            // $dataArray['submission_id'] = $submissionId;
+            // Link the new data model to the current submission
+            $dataArray['submission_id'] = $submissionId;
 
             // access the value of each ODK variable from a deeply nested array using "dot" notation
             foreach ($schema as $schemaItem) {
@@ -750,16 +750,12 @@ class OdkLinkService
                 }
             }
 
-            // Link the new data model to the current submission
-            $dataArray['submission_id'] = $submissionId;
+            $newDataArray = $this->prepareDataArray($section->is_repeat, $entry, $section, $schema, $class, $columnNames, $submissionId);
 
-            $newDataArray = $this->prepareDataArray($section->is_repeat, $entry, $schema, $class, $columnNames, $submissionId);
-            $newDataArray['submission_id'] = $submissionId;
-
-            logger('$dataArray');
+            logger('main survey $dataArray');
             logger($dataArray);
 
-            logger('$newDataArray');
+            logger('main survey $newDataArray');
             logger($newDataArray);
 
             // delete previously stored records in this table (if any)
@@ -771,7 +767,7 @@ class OdkLinkService
     }
 
 
-    private function prepareDataArray($isRepeat, $entry, $schema, $class, $columnNames, $submissionId)
+    private function prepareDataArray($isRepeat, $entry, $section, $schema, $class, $columnNames, $submissionId)
     {
         // initialise array
         $result = [];
@@ -781,6 +777,7 @@ class OdkLinkService
 
         // extract values from main survey to array
         if ($isRepeat === 0) {
+
             // access the value of each ODK variable from a deeply nested array using "dot" notation
             foreach ($schema as $schemaItem) {
                 $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
@@ -793,6 +790,28 @@ class OdkLinkService
 
             // extract values from repeat group to array
         } else {
+
+            logger('$entry');
+            logger($entry);
+
+            foreach ($schema as $schemaItem) {
+                $pathLength = Str::length($schemaItem['path']);
+                $position = Str::position($schemaItem['path'], $section->structure_item);
+                $lengthToCut = $pathLength - $position;
+
+                $itemPath = Str::substr($schemaItem['path'], $position + Str::length($section->structure_item), $lengthToCut);
+                // dump('$itemPath : ' . $itemPath);
+
+                $fullItemPath = 'rg' . Str::replace('/', '.', $itemPath);
+                // dump('$fullItemPath : ' . $fullItemPath);
+
+                $value = Arr::get($entry, $fullItemPath);
+                // dump($schemaItem['name'] . ' : ' . $value);
+
+                if (in_array($schemaItem['name'], $columnNames)) {
+                    $dataArray[$schemaItem['name']] = $value;
+                }
+            }
         }
 
         return $result;
@@ -929,6 +948,9 @@ class OdkLinkService
                         // get array element as record
                         $repeatGroupEntry = ['rg' => $repeatGroupRecord];
 
+                        logger('$repeatGroupEntry');
+                        logger($repeatGroupEntry);
+
                         foreach ($schema as $schemaItem) {
                             $pathLength = Str::length($schemaItem['path']);
                             $position = Str::position($schemaItem['path'], $section->structure_item);
@@ -947,6 +969,15 @@ class OdkLinkService
                                 $dataArray[$schemaItem['name']] = $value;
                             }
                         }
+
+                        $newDataArray = $this->prepareDataArray($section->is_repeat, $repeatGroupEntry, $section, $schema, $class, $columnNames, $submissionId);
+
+                        logger('repeat group $dataArray');
+                        logger($dataArray);
+
+                        logger('repeat group $newDataArray');
+                        logger($newDataArray);
+
 
                         // create a new database record
                         $class::create($dataArray);

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -869,7 +869,7 @@ class OdkLinkService
                 // Question: any idea to avoid adding extra double quote character in JSON content...?
                 $respondentName = Arr::get($entry, 'root.farm_info.respondent_name');
                 $identifiers = ['name' => $respondentName];
-                $result['identifiers'] = json_encode($identifiers);
+                $result['identifiers'] = $identifiers;
                 // logger($result['identifiers']);
 
                 $result['location_id'] = Arr::get($entry, 'root.reg.final_location_id');

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -731,35 +731,11 @@ class OdkLinkService
                 return;
             }
 
-            // get all column names of a table
-            $columnNames = Schema::getColumnListing($model->getTable());
-
-            // initialise data array
-            $dataArray = [];
-
-            // Link the new data model to the current submission
-            $dataArray['submission_id'] = $submissionId;
-
-            // access the value of each ODK variable from a deeply nested array using "dot" notation
-            foreach ($schema as $schemaItem) {
-                $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
-                $value = Arr::get($entry, $itemPath);
-
-                if ($class && in_array($schemaItem['name'], $columnNames)) {
-                    $dataArray[$schemaItem['name']] = $value;
-                }
-            }
-
-            $newDataArray = $this->prepareDataArray($section->is_repeat, $entry, $section, $schema, $class, $columnNames, $submissionId);
-
-            logger('main survey $dataArray');
-            logger($dataArray);
-
-            logger('main survey $newDataArray');
-            logger($newDataArray);
-
             // delete previously stored records in this table (if any)
-            $class::where('submission_id', $dataArray['submission_id'])->delete();
+            $class::where('submission_id', $submissionId)->delete();
+
+            // get data array from main survey
+            $dataArray = $this->prepareDataArray($entry, $section, $schema, $class, $model, $submissionId);
 
             // create a new database record
             $class::create($dataArray);
@@ -767,7 +743,8 @@ class OdkLinkService
     }
 
 
-    private function prepareDataArray($isRepeat, $entry, $section, $schema, $class, $columnNames, $submissionId)
+    // a generalised function to extract values from main survey and repeat group entry, returns an array for further processing
+    private function prepareDataArray($entry, $section, $schema, $class, $model, $submissionId): array
     {
         // initialise array
         $result = [];
@@ -775,8 +752,11 @@ class OdkLinkService
         // add submission Id to array
         $result['submission_id'] = $submissionId;
 
+        // get all column names of a table
+        $columnNames = Schema::getColumnListing($model->getTable());
+
         // extract values from main survey to array
-        if ($isRepeat === 0) {
+        if ($section->is_repeat == 0) {
 
             // access the value of each ODK variable from a deeply nested array using "dot" notation
             foreach ($schema as $schemaItem) {
@@ -790,9 +770,6 @@ class OdkLinkService
 
             // extract values from repeat group to array
         } else {
-
-            logger('$entry');
-            logger($entry);
 
             foreach ($schema as $schemaItem) {
                 $pathLength = Str::length($schemaItem['path']);
@@ -809,7 +786,7 @@ class OdkLinkService
                 // dump($schemaItem['name'] . ' : ' . $value);
 
                 if (in_array($schemaItem['name'], $columnNames)) {
-                    $dataArray[$schemaItem['name']] = $value;
+                    $result[$schemaItem['name']] = $value;
                 }
             }
         }
@@ -923,65 +900,30 @@ class OdkLinkService
                 $model = new $class;
 
                 // check database table existence
-                if (Schema::hasTable($model->getTable())) {
-                    // get all column names of a table
-                    $columnNames = Schema::getColumnListing($model->getTable());
+                if (!Schema::hasTable($model->getTable())) {
+                    return;
+                }
 
-                    // initialise data array
-                    $dataArray = [];
+                // delete previously stored records in this table (if any)
+                $class::where('submission_id', $submissionId)->delete();
 
-                    // delete previously stored records in this table (if any)
-                    $class::where('submission_id', $submissionId)->delete();
+                // handle each record in repeat group
+                foreach ($repeatGroupArray as $repeatGroupRecord) {
+                    // dump($repeatGroupRecord);
 
-                    // handle each record in repeat group
-                    foreach ($repeatGroupArray as $repeatGroupRecord) {
-                        // dump($repeatGroupRecord);
-
-                        // link new data model to the current submission
-                        $dataArray['submission_id'] = $submissionId;
-
-                        // find the parent (if exists)
-                        if ($parentDataset = $section->dataset?->parent) {
-                            $parentClass = $section->dataset?->entity_model;
-                        }
-
-                        // get array element as record
-                        $repeatGroupEntry = ['rg' => $repeatGroupRecord];
-
-                        logger('$repeatGroupEntry');
-                        logger($repeatGroupEntry);
-
-                        foreach ($schema as $schemaItem) {
-                            $pathLength = Str::length($schemaItem['path']);
-                            $position = Str::position($schemaItem['path'], $section->structure_item);
-                            $lengthToCut = $pathLength - $position;
-
-                            $itemPath = Str::substr($schemaItem['path'], $position + Str::length($section->structure_item), $lengthToCut);
-                            // dump('$itemPath : ' . $itemPath);
-
-                            $fullItemPath = 'rg' . Str::replace('/', '.', $itemPath);
-                            // dump('$fullItemPath : ' . $fullItemPath);
-
-                            $value = Arr::get($repeatGroupEntry, $fullItemPath);
-                            // dump($schemaItem['name'] . ' : ' . $value);
-
-                            if (in_array($schemaItem['name'], $columnNames)) {
-                                $dataArray[$schemaItem['name']] = $value;
-                            }
-                        }
-
-                        $newDataArray = $this->prepareDataArray($section->is_repeat, $repeatGroupEntry, $section, $schema, $class, $columnNames, $submissionId);
-
-                        logger('repeat group $dataArray');
-                        logger($dataArray);
-
-                        logger('repeat group $newDataArray');
-                        logger($newDataArray);
-
-
-                        // create a new database record
-                        $class::create($dataArray);
+                    // find the parent (if exists)
+                    if ($parentDataset = $section->dataset?->parent) {
+                        $parentClass = $section->dataset?->entity_model;
                     }
+
+                    // get array element as record
+                    $repeatGroupEntry = ['rg' => $repeatGroupRecord];
+
+                    // get data array from repeat group entry
+                    $dataArray = $this->prepareDataArray($repeatGroupEntry, $section, $schema, $class, $model, $submissionId);
+
+                    // create a new database record
+                    $class::create($dataArray);
                 }
             }
         } else {

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -617,7 +617,7 @@ class OdkLinkService
 
             //££
             // Add temporary code to retrieve one submission only
-            break;
+            // break;
             //££
         }
 
@@ -738,6 +738,8 @@ class OdkLinkService
 
             // get data array from main survey
             $dataArray = $this->prepareDataArray($entry, $section, $schema, $model, $submissionId);
+            logger($dataArray);
+            logger('***** ' . $dataArray['farm_id']);
 
             // create a new database record
             $class::create($dataArray);
@@ -757,24 +759,19 @@ class OdkLinkService
         // get all column names of a table
         $columnNames = Schema::getColumnListing($model->getTable());
 
-        // $foreignKeyDetails = Schema::getForeignKeys($model->getTable());
-        // logger('table: ' . $model->getTable());
-
-        // hardcode temporary for testing
-        $foreignKeyDetails = Schema::getForeignKeys('xlsform_template_sections');
-        logger('table: ' . 'xlsform_template_sections');
+        // get all foreign key details of a table
+        $foreignKeyDetails = Schema::getForeignKeys($model->getTable());
+        logger('table: ' . $model->getTable());
 
         logger('$foreignKeyDetails: ');
         logger($foreignKeyDetails);
 
+        // store foreign key column name and foreign key table name in associative array
         // TODO: find Laravel array helper function to do the same in a simpler way
-        // use associative array, column name => foreign key table name
         $foreignKeyColumnNames = [];
         foreach ($foreignKeyDetails as $foreignKey) {
             foreach ($foreignKey['columns'] as $foreignKeyColumn) {
                 logger('foreign_key_column_name: ' . $foreignKeyColumn);
-                // array_push($foreignKeyColumnNames, $foreignKeyColumn);
-
                 $foreignKeyColumnNames[$foreignKeyColumn] = $foreignKey['foreign_table'];
             }
             logger('foreign_table: ' . $foreignKey['foreign_table']);
@@ -783,37 +780,6 @@ class OdkLinkService
         logger('$foreignKeyColumnNames: ');
         logger($foreignKeyColumnNames);
 
-        $attributeName = 'parent_id';
-
-        if (array_key_exists($attributeName, $foreignKeyColumnNames)) {
-            // find foreign key's table name
-            // $foreignKeyTableName = $foreignKeyColumnNames[$attributeName];
-
-            // hardcode temporary for testing
-            $foreignKeyTableName = 'users';
-
-
-            $model = HelperService::getModelByTablename($foreignKeyTableName);
-
-            if ($model == null) {
-                logger('Cannot find related model for this database table');
-            } else {
-                logger('Found related model for this database table');
-
-                logger('$attributeName: ' . $attributeName);
-                logger('$foreignKeyTableName: ' . $foreignKeyTableName);
-
-                // get foreign key table columns
-                $foreignKeyTableColumnNames = Schema::getColumnListing($foreignKeyTableName);
-
-                // get values to create a new record in foreign key table
-                $foreignKeyTableDataArray = ['name' => 'Testing', 'email' => 'testing@example.com', 'password' => '12345678'];
-
-                $record = $model::create($foreignKeyTableDataArray);
-            }
-
-            // set foreign key table new record id to foreign key column in this table
-        }
 
 
         // access the value of each ODK variable from a deeply nested array using "dot" notation
@@ -840,6 +806,39 @@ class OdkLinkService
                 // dump($schemaItem['name'] . ' : ' . $value);
             }
 
+
+            // special handling for ODK attribute serves as foreign key, and new record need to be created in foreign key table
+            if ($value == -99 && array_key_exists($schemaItem['name'], $foreignKeyColumnNames)) {
+
+                // find foreign key's table name
+                $foreignKeyTableName = $foreignKeyColumnNames[$schemaItem['name']];
+
+                // try to find the corresponding model by table name
+                $model = HelperService::getModelByTablename($foreignKeyTableName);
+
+                if ($model == null) {
+                    logger('Cannot find related model for this database table');
+                } else {
+                    logger('Found related model for this database table');
+
+                    logger('foreign key column name: ' . $schemaItem['name']);
+                    logger('$foreignKeyTableName: ' . $foreignKeyTableName);
+
+                    $foreignKeyTableDataArray = $this->prepareForeignKeyTableDataArray($schemaItem['name']);
+                    logger($foreignKeyTableDataArray);
+
+                    $newRecord = $model::create($foreignKeyTableDataArray);
+                    logger($newRecord);
+
+                    // set foreign key table new record id to foreign key column in this table
+                    $result[$schemaItem['name']] = $newRecord->id;
+                }
+
+                // foreign key ODK attribute handling is completed, contine to handle next ODK variable
+                continue;
+            }
+
+
             // handle different kind of data value
             if ($schemaItem['type'] === 'geopoint') {
                 $gpsData = $this->extractGpsData($schemaItem, $columnNames, $value);
@@ -847,6 +846,27 @@ class OdkLinkService
             } elseif (in_array($schemaItem['name'], $columnNames)) {
                 $result[$schemaItem['name']] = $value;
             }
+        }
+
+        return $result;
+    }
+
+
+    // a function to prepare data array for creating a new record in foreign key table
+    // P.S. It is not appropriate to have application specific code in this package, need to find
+    // a way to move this to main application in later time
+    private function prepareForeignKeyTableDataArray($foreignKeyName): array
+    {
+        logger('OdkLinkService.prepareForeignKeyTableDataArray()');
+
+        $result = [];
+
+        switch ($foreignKeyName) {
+            case 'farm_id':
+                $result = ['location_id' => 1, 'team_code' => 'C10001'];
+                break;
+
+            default:
         }
 
         return $result;

--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -2,33 +2,29 @@
 
 namespace Stats4sd\FilamentOdkLink\Services;
 
-use Carbon\Carbon;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Http;
-use Maatwebsite\Excel\Facades\Excel;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Storage;
 use App\Models\SurveyData\SimpleFormMain;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Client\RequestException;
-use Stats4sd\FilamentOdkLink\Imports\XlsImport;
-use Stats4sd\FilamentOdkLink\Exports\SurveyExport;
-use Stats4sd\FilamentOdkLink\Exports\SqlViewExport;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Entity;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\AppUser;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
-use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\OdkProject;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\EntityValue;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Facades\Excel;
 use Stats4sd\FilamentOdkLink\Exports\DatasetModelsExport;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformVersion;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+use Stats4sd\FilamentOdkLink\Exports\SurveyExport;
+use Stats4sd\FilamentOdkLink\Imports\XlsImport;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Entity;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\EntityValue;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsFormDrafts;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\OdkProject;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformVersion;
 
 /**
  * All ODK Aggregation services should be able to handle ODK forms, so this interface should always be used.
@@ -726,10 +722,12 @@ class OdkLinkService
             $model = new $class;
 
             // check database table existence
-            if (Schema::hasTable($model->getTable())) {
-                // get all column names of a table
-                $columnNames = Schema::getColumnListing($model->getTable());
+            if (!Schema::hasTable($model->getTable())) {
+                return;
             }
+
+            // get all column names of a table
+            $columnNames = Schema::getColumnListing($model->getTable());
 
             // initialise data array
             $dataArray = [];
@@ -742,7 +740,26 @@ class OdkLinkService
                 $itemPath = 'root' . Str::replace('/', '.', $schemaItem['path']);
                 $value = Arr::get($entry, $itemPath);
 
-                // dump($schemaItem['name'] . ' : ' . $value);
+                // handle GPS data
+                // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
+                if ($schemaItem['type'] === 'geopoint') {
+                    if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
+                        $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
+                    }
+
+                    if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
+                        $dataArray[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
+                    }
+
+                    if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
+                        $dataArray[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
+                    }
+
+                    if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
+                        $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
+                    }
+                }
+
 
                 if ($class && in_array($schemaItem['name'], $columnNames)) {
                     $dataArray[$schemaItem['name']] = $value;
@@ -870,6 +887,9 @@ class OdkLinkService
                     // initialise data array
                     $dataArray = [];
 
+                    // delete previously stored records in this table (if any)
+                    $class::where('submission_id', $submissionId)->delete();
+
                     // handle each record in repeat group
                     foreach ($repeatGroupArray as $repeatGroupRecord) {
                         // dump($repeatGroupRecord);
@@ -899,13 +919,30 @@ class OdkLinkService
                             $value = Arr::get($repeatGroupEntry, $fullItemPath);
                             // dump($schemaItem['name'] . ' : ' . $value);
 
+                            // handle GPS data
+                            // We expect the data model to have columns for latitude, longitude, altitude and accuracy in the format of $varName + '_' + 'latitude', etc.
+                            if ($schemaItem['type'] === 'geopoint') {
+                                if (in_array($schemaItem['name'] . '_' . 'latitude', $columnNames, true)) {
+                                    $dataArray[$schemaItem['name'] . '_' . 'latitude'] = $value['coordinates'][0];
+                                }
+
+                                if (in_array($schemaItem['name'] . '_' . 'longitude', $columnNames, true)) {
+                                    $dataArray[$schemaItem['name'] . '_' . 'longitude'] = $value['coordinates'][1];
+                                }
+
+                                if (in_array($schemaItem['name'] . '_' . 'altitude', $columnNames, true)) {
+                                    $dataArray[$schemaItem['name'] . '_' . 'altitude'] = $value['coordinates'][2];
+                                }
+
+                                if (in_array($schemaItem['name'] . '_' . 'accuracy', $columnNames, true)) {
+                                    $dataArray[$schemaItem['name'] . '_' . 'accuracy'] = $value['properties']['accuracy'];
+                                }
+                            }
+
                             if (in_array($schemaItem['name'], $columnNames)) {
                                 $dataArray[$schemaItem['name']] = $value;
                             }
                         }
-
-                        // delete previously stored records in this table (if any)
-                        $class::where('submission_id', $dataArray['submission_id'])->delete();
 
                         // create a new database record
                         $class::create($dataArray);


### PR DESCRIPTION
Adds basic handling of geopoints into custom data models from ODK forms. 

This also fixes a potential bug: previously, all $class entries with the current $submissionId were deleted at the end of every foeach loop, meaning that only the final entry from each repeat persisted in the table. 

This PR moves that call to before the foreach loop, so the deletion only happens once. 


@dan-tang-ssd - this might be just for you to take the GPS code into your work. As you're refactoring the functions a bit first, this might become old very quickly. 