### PR TITLE
append extra rows to csv file exports

### DIFF
--- a/src/Exports/DatasetModelsExport.php
+++ b/src/Exports/DatasetModelsExport.php
@@ -43,7 +43,8 @@ class DatasetModelsExport implements FromCollection, WithHeadings, WithStrictNul
             ->get()
             ->map(function ($entry) {
                 return $entry->getCsvContentsForOdk($this->owner);
-            });
+            })
+            ->concat(collect($this->dataset->entity_model::getExtraCsvRows()));
     }
 
     public function headings(): array


### PR DESCRIPTION
PR to accompany https://github.com/stats4sd/tape-data-system/pull/62. Adds the ability to concat() rows to the end of csv lookup files as they are exported, using the data model's `getExtraCsvRows()` method output. 

