### PR TITLE
Fix Missing Repeat Group

### DIFF
--- a/src/Services/OdkLinkService.php
+++ b/src/Services/OdkLinkService.php
@@ -793,10 +793,10 @@ class OdkLinkService
                 // extract value from repeat group
             } else {
                 $pathLength = Str::length($schemaItem['path']);
-                $position = Str::position($schemaItem['path'], $section->structure_item);
+                $position = Str::position($schemaItem['path'], '/' . $section->structure_item . '/');
                 $lengthToCut = $pathLength - $position;
 
-                $itemPath = Str::substr($schemaItem['path'], $position + Str::length($section->structure_item), $lengthToCut);
+                $itemPath = Str::substr($schemaItem['path'], ($position + 1) + Str::length($section->structure_item), $lengthToCut);
                 // dump('$itemPath : ' . $itemPath);
 
                 $fullItemPath = 'rg' . Str::replace('/', '.', $itemPath);
@@ -937,10 +937,10 @@ class OdkLinkService
         $schemaPaths = $schema->pluck('path')->toArray();
         // dump($schemaPaths[0]);
 
-        $position = Str::position($schemaPaths[0], $section->structure_item);
+        $position = Str::position($schemaPaths[0], '/' . $section->structure_item . '/');
 
         // construct the path for getting an array of repeat group
-        $repeatGroupArrayPath = 'root' . Str::replace('/', '.', Str::substr($schemaPaths[0], 0, $position)) . $section->structure_item;
+        $repeatGroupArrayPath = 'root' . Str::replace('/', '.', Str::substr($schemaPaths[0], 0, $position)) . '.' . $section->structure_item;
         // dump($repeatGroupArrayPath);
 
         // get the array for repeat group
@@ -970,11 +970,13 @@ class OdkLinkService
                 $repeatGroupEntry = ['rg' => $repeatGroupRecord];
 
                 foreach ($schema as $schemaItem) {
+                    // dump('$schemaItem[path] : ' . $schemaItem['path']);
+
                     $pathLength = Str::length($schemaItem['path']);
-                    $position = Str::position($schemaItem['path'], $section->structure_item);
+                    $position = Str::position($schemaItem['path'], '/' . $section->structure_item . '/');
                     $lengthToCut = $pathLength - $position;
 
-                    $itemPath = Str::substr($schemaItem['path'], $position + Str::length($section->structure_item), $lengthToCut);
+                    $itemPath = Str::substr($schemaItem['path'], ($position + 1) + Str::length($section->structure_item), $lengthToCut);
                     // dump('$itemPath : ' . $itemPath);
 
                     $fullItemPath = 'rg' . Str::replace('/', '.', $itemPath);
@@ -1009,10 +1011,10 @@ class OdkLinkService
         $schemaPaths = $schema->pluck('path')->toArray();
         // dump($schemaPaths[0]);
 
-        $position = Str::position($schemaPaths[0], $section->structure_item);
+        $position = Str::position($schemaPaths[0], '/' . $section->structure_item . '/');
 
         // construct the path for getting an array of repeat group
-        $repeatGroupArrayPath = 'root' . Str::replace('/', '.', Str::substr($schemaPaths[0], 0, $position)) . $section->structure_item;
+        $repeatGroupArrayPath = 'root' . Str::replace('/', '.', Str::substr($schemaPaths[0], 0, $position)) . '.' . $section->structure_item;
         // dump($repeatGroupArrayPath);
 
         // get the array for repeat group


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/tape-data-system/issues/77

---

Root cause:
 - Searching for xlsform_template_sections.structure_item returns incorrect result
 - It happens when structure item string appear before the actual repeat group name in path
 - Easy to happen when structure item string consists of common character combinations, e.g. "ac", 'm', etc.

---

Error Examples:

Path: /step2/agdiv/outputs_grp/topactiv/ac/ac_num
Strcture_item: ac
Search for "ac"
Incorrect result: /step2/agdiv/outputs_grp/topac

Path: /step2/agdiv/inputs_grp/machin_grp/m/m_number
Strcture_item: m
Search for "m"
Incorrect result: /step2/agdiv/inputs_grp/m


---

Solution:
 - Enhance seaching for structure item, add slash before and after it for searching the repeat group name

---

Correction Examples:

Path: /step2/agdiv/outputs_grp/topactiv/ac/ac_num
Strcture_item: ac
Search for "/ac/"
Correct result: /step2/agdiv/outputs_grp/topactiv/ac

Path: /step2/agdiv/inputs_grp/machin_grp/m/m_number
Strcture_item: m
Search for "/m/"
Correct result: /step2/agdiv/inputs_grp/machin_grp/m
