### PR TITLE
Ux Updates & Custom Xlsforms

### DIFF
--- a/src/Filament/Resources/CustomXlsformTemplateResource.php
+++ b/src/Filament/Resources/CustomXlsformTemplateResource.php
@@ -10,6 +10,8 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
 
+// Use this resource for an admin panel
+// This resource shows all custom templates which are owned by specific teams
 
 class CustomXlsformTemplateResource extends Resource
 {

--- a/src/Filament/Resources/CustomXlsformTemplateResource.php
+++ b/src/Filament/Resources/CustomXlsformTemplateResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources;
+
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+
+class CustomXlsformTemplateResource extends Resource
+{
+
+    protected static ?string $model = XlsformTemplate::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $slug = 'custom-xlsform-templates';
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('owner_type', '!=', Platform::class);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('owner.name')
+                    ->label('Owner')
+                    ->url(fn($record) => "/app/{$record->owner->slug}")
+                    ->openUrlInNewTab()
+                    ->color('primary'),
+                Tables\Columns\IconColumn::make('has_version')
+                    ->label('Deployed?')
+                    ->state(fn(Xlsformtemplate $record) => $record->xlsforms->count() > 0)
+                    ->boolean(),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('View template')
+                    ->url(fn($record) => "/app/{$record->owner->slug}/xlsforms/custom-xlsform-templates")
+                    ->openUrlInNewTab()
+                    ->icon('heroicon-o-eye'),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCustomXlsformTemplates::route('/'),
+        ];
+    }
+}

--- a/src/Filament/Resources/CustomXlsformTemplateResource/Pages/ListCustomXlsformTemplates.php
+++ b/src/Filament/Resources/CustomXlsformTemplateResource/Pages/ListCustomXlsformTemplates.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource;
+
+class ListCustomXlsformTemplates extends ListRecords
+{
+    protected static string $resource = CustomXlsformTemplateResource::class;
+
+    protected ?string $heading = 'Custom Xlsform Templates';
+
+    public function getBreadcrumbs(): array
+    {
+        return [];
+    }
+
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
@@ -22,6 +22,9 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
 
+// Use this resource for a panel scoped to a team
+// This resource is for a team to add their own custom templates
+
 class TeamCustomXlsformTemplateResource extends Resource
 {
     protected static ?string $model = XlsformTemplate::class;

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
@@ -14,9 +14,12 @@ use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Infolists\Components\RepeatableEntry;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages\CreateTeamCustomXlsformTemplate;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages\EditTeamCustomXlsformTemplate;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages\ListTeamCustomXlsformTemplates;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages\ViewTeamCustomXlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
-use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
 
 class TeamCustomXlsformTemplateResource extends Resource
@@ -261,10 +264,10 @@ class TeamCustomXlsformTemplateResource extends Resource
     public static function getPages(): array
     {
         return [
-            // 'index' => Pages\ListTeamCustomXlsformTemplates::route('/'),
-            // 'create' => Pages\CreateTeamCustomXlsformTemplate::route('/create'),
-            // 'edit' => Pages\EditTeamCustomXlsformTemplate::route('/{record}/edit'),
-            // 'view' => Pages\ViewTeamCustomXlsformTemplate::route('/{record}'),
+             'index' => ListTeamCustomXlsformTemplates::route('/'),
+             'create' => CreateTeamCustomXlsformTemplate::route('/create'),
+             'edit' => EditTeamCustomXlsformTemplate::route('/{record}/edit'),
+             'view' => ViewTeamCustomXlsformTemplate::route('/{record}'),
         ];
     }
 }

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources;
+
+use Awcodes\FilamentTableRepeater\Components\TableRepeater;
+use Filament\Infolists\Components\ViewEntry;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Facades\Filament;
+use Filament\Infolists\Infolist;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Components\RepeatableEntry;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+
+class TeamCustomXlsformTemplateResource extends Resource
+{
+    protected static ?string $model = XlsformTemplate::class;
+    public static ?string $label = 'Custom Xlsform Templates';
+    protected static ?string $slug = 'custom-xlsform-templates';
+
+    protected static ?string $navigationIcon = 'heroicon-o-user-group';
+    protected static ?string $navigationLabel = 'Custom ODK Templates';
+
+    protected static bool $isScopedToTenant = false;
+
+    //  manually scope to Team tenant
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereHas('owner', function (Builder $query) {
+                $query->where('id', Filament::getTenant()->id);
+            });
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\ViewColumn::make('required_fixed_media_count')
+                    ->label('Fixed Media')
+                    ->view('filament-odk-link::filament.tables.columns.required-fixed-media-count'),
+                Tables\Columns\ViewColumn::make('required_data_media_count')
+                    ->label('Datasets')
+                    ->view('filament-odk-link::filament.tables.columns.required-data-media-count'),
+                Tables\Columns\CheckboxColumn::make('available')
+                    ->label('Available for use?')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('has_version')
+                    ->label('Deployed?')
+                    ->state(fn(Xlsformtemplate $record) => $record->xlsforms->count() > 0)
+                    ->boolean(),
+
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make()->label('Edit Media & Data'),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function infoList(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                Section::make('Xlsform Details')
+                    ->collapsed()
+                    ->schema([
+                        TextEntry::make('title'),
+                        TextEntry::make('xlsfile_name')
+                            ->url(fn(?XlsformTemplate $record): string => $record?->getFirstMediaUrl('xlsform_file')),
+                        IconEntry::make('available')
+                            ->label('Available to Platform users?')
+                            ->icon(fn(bool $state): string => match ($state) {
+                                false => 'heroicon-o-no-symbol',
+                                true => 'heroicon-o-check-circle',
+                            }),
+                    ])
+                    ->columns([
+                        'xl' => 3,
+                        'lg' => 2,
+                        'md' => 1,
+                    ]),
+                Section::make('Attached media files')
+                    ->collapsed()
+                    ->schema([
+                        RepeatableEntry::make('requiredFixedMedia')
+                            ->schema([
+                                TextEntry::make('name')
+                                    ->url(fn(?RequiredMedia $record): string => $record->getFirstMediaUrl()),
+                                TextEntry::make('type'),
+                                IconEntry::make('status')
+                                    ->icon(fn(int $state): string => match ($state) {
+                                        1 => 'heroicon-o-check-circle',
+                                        0 => 'heroicon-o-x-circle',
+                                    })
+                                    ->color(fn(int $state): string => match ($state) {
+                                        1 => 'success',
+                                        0 => 'gray',
+                                    }),
+                            ])
+                            ->columns([
+                                '2xl' => 3,
+                                'xl' => 2,
+                                'lg' => 1,
+                            ]),
+
+                        RepeatableEntry::make('requiredDataMedia')
+                            ->schema([
+                                TextEntry::make('name')
+                                    ->url(fn(?RequiredMedia $record): string => $record->getFirstMediaUrl()),
+                                TextEntry::make('full_type'),
+                                IconEntry::make('status')
+                                    ->icon(fn(int $state): string => match ($state) {
+                                        1 => 'heroicon-o-check-circle',
+                                        0 => 'heroicon-o-x-circle',
+                                    })
+                                    ->color(fn(int $state): string => match ($state) {
+                                        1 => 'success',
+                                        0 => 'gray',
+                                    }),
+                            ])->columns([
+                                'lg' => 3,
+                                'md' => 2,
+                                'sm' => 1,
+                            ]),
+                    ]),
+                Section::make('Main Survey')
+                    ->collapsed()
+                    ->schema([
+                        RepeatableEntry::make('schema')
+                            ->label('List of variables in the main survey')
+                            ->schema([
+                                TextEntry::make('name')->hiddenLabel(),
+                                TextEntry::make('type')->hiddenLabel(),
+                            ])
+                            ->visible(fn(?XlsformTemplate $record): bool => $record->rootSection->schema->count() < 5),
+
+                        ViewEntry::make('schema')
+                            ->view('filament-odk-link::filament.infolists.components.xlsform-section-schema-modal-link')
+                            ->registerActions([
+                                \Filament\Infolists\Components\Actions\Action::make('viewSchema')
+                                    ->label('View variable list')
+                                    ->icon('heroicon-o-eye')
+                                    ->form(function (?XlsformTemplate $record) {
+                                        return [
+                                            TableRepeater::make('schema')
+                                                ->label('List of variables in the main survey')
+                                                ->deletable(false)
+                                                ->reorderable(false)
+                                                ->addable(false)
+                                                ->schema([
+                                                    Forms\Components\TextInput::make('name')->disabled()->hiddenLabel(),
+                                                    Forms\Components\TextInput::make('type')->disabled()->hiddenLabel(),
+                                                ]),
+                                        ];
+                                    })
+                                    ->fillForm(function (?XlsformTemplate $record): array {
+                                        return [
+                                            'schema' => $record?->rootSection->schema,
+                                        ];
+                                    })
+                                    ->modalSubmitAction(false)
+                                    ->modalCancelActionLabel('Close'),
+                            ])
+                            ->visible(fn(?XlsformTemplate $record): bool => $record->rootSection->schema->count() >= 5),
+
+                        TextEntry::make('rootSection.dataset.name')->label('Submission data is added to:')
+                            ->placeholder('No dataset linked')
+                            ->inlineLabel()
+                    ]),
+
+                Section::make('Repeat Groups')
+                    ->collapsed()
+                    ->schema([
+                        RepeatableEntry::make('repeatingSections')
+                            ->columns([
+                                'lg' => 3,
+                                'md' => 2,
+                                'sm' => 1,
+                            ])
+                            ->hiddenLabel()
+                            ->schema(function ($state) {
+                                return [
+                                    TextEntry::make('structure_item')->label('Repeat Name'),
+
+                                    ViewEntry::make('schema')
+                                        ->view('filament-odk-link::filament.forms.components.xlsform-section-schema-modal-link')
+                                        ->registerActions([
+                                            \Filament\Infolists\Components\Actions\Action::make('viewSchema')
+                                                ->label('View variable list')
+                                                ->icon('heroicon-o-eye')
+                                                ->form(function (?XlsformTemplateSection $record) {
+                                                    return [
+                                                        TableRepeater::make('schema')
+                                                            ->label('List of variables in the repeat group')
+                                                            ->deletable(false)
+                                                            ->reorderable(false)
+                                                            ->addable(false)
+                                                            ->schema([
+                                                                Forms\Components\TextInput::make('name')->disabled()->hiddenLabel(),
+                                                                Forms\Components\TextInput::make('type')->disabled()->hiddenLabel(),
+                                                            ]),
+                                                    ];
+                                                })
+                                                ->fillForm(fn(?XlsformTemplateSection $record): array => [
+                                                    'schema' => $record->schema,
+                                                ])
+                                                ->modalSubmitAction(false)
+                                                ->modalCancelActionLabel('Close'),
+                                        ]),
+
+                                    TextEntry::make('dataset.name')->label('Data from this repeat group is added to:')
+                                        ->placeholder('No dataset linked')
+                                        ->inlineLabel()
+                                ];
+                            }),
+
+                    ])
+                    ->visible(fn(?XlsformTemplate $record): bool => $record->repeatingSections->count() > 0),
+
+                Section::make('Draft Testing')
+                    ->collapsed()
+                    ->schema([
+
+                        // show reminder text
+                        TextEntry::make('reminder')
+                            ->label('You may use the QR code and link below to test this form template before making it available to teams. Any submissions sent to this draft version will not be saved. If you want to do a more comprehensive test and review the data in the platform, we recommend using a "test" team and deploying a live version of the form to that team.'),
+
+                        // show QR code of ODK form draft version
+                        ViewEntry::make('qr_code')
+                            ->label('Scan the QR code below in ODK Collect to view the test form.')
+                            ->view('filament-odk-link::filament.infolists.entries.draft-testing-qr-code'),
+
+                        // open URL in browser new tab
+                        TextEntry::make('enketo_draft_url')->label('Click below link to view ODK form in browser')
+                            ->url(fn(?XlsformTemplate $record): string => $record->enketo_draft_url)
+                            ->openUrlInNewTab(),
+
+                    ]),
+
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            // 'index' => Pages\ListTeamCustomXlsformTemplates::route('/'),
+            // 'create' => Pages\CreateTeamCustomXlsformTemplate::route('/create'),
+            // 'edit' => Pages\EditTeamCustomXlsformTemplate::route('/{record}/edit'),
+            // 'view' => Pages\ViewTeamCustomXlsformTemplate::route('/{record}'),
+        ];
+    }
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/CreateTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/CreateTeamCustomXlsformTemplate.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\CreateXlsformTemplate;
+
+class CreateTeamCustomXlsformTemplate extends CreateXlsformTemplate
+
+{
+    protected static string $resource = CustomXlsformTemplateResource::class;
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/CreateTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/CreateTeamCustomXlsformTemplate.php
@@ -1,12 +1,13 @@
 <?php
 
 
-namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
 
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\CreateXlsformTemplate;
 
 class CreateTeamCustomXlsformTemplate extends CreateXlsformTemplate
 
 {
-    protected static string $resource = CustomXlsformTemplateResource::class;
+    protected static string $resource = TeamCustomXlsformTemplateResource::class;
 }

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/EditTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/EditTeamCustomXlsformTemplate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\EditXlsformTemplate;
+
+class EditTeamCustomXlsformTemplate extends EditXlsformTemplate
+{
+    protected static string $resource = CustomXlsformTemplateResource::class;
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/EditTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/EditTeamCustomXlsformTemplate.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
 
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\EditXlsformTemplate;
 
 class EditTeamCustomXlsformTemplate extends EditXlsformTemplate
 {
-    protected static string $resource = CustomXlsformTemplateResource::class;
+    protected static string $resource = TeamCustomXlsformTemplateResource::class;
 }

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ListTeamCustomXlsformTemplates.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ListTeamCustomXlsformTemplates.php
@@ -1,15 +1,16 @@
 <?php
 
-namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
 
 use App\Filament\App\Clusters\XlsformsCluster\Resources\CustomXlsformTemplateResource;
 use App\Filament\App\Clusters\XlsformsCluster\Widgets\CustomOdkTemplatesWidget;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource;
 
 class ListTeamCustomXlsformTemplates extends ListRecords
 {
-    protected static string $resource = CustomXlsformTemplateResource::class;
+    protected static string $resource = TeamCustomXlsformTemplateResource::class;
 
     protected ?string $heading = 'Custom Xlsform Templates';
 

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ListTeamCustomXlsformTemplates.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ListTeamCustomXlsformTemplates.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use App\Filament\App\Clusters\XlsformsCluster\Resources\CustomXlsformTemplateResource;
+use App\Filament\App\Clusters\XlsformsCluster\Widgets\CustomOdkTemplatesWidget;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeamCustomXlsformTemplates extends ListRecords
+{
+    protected static string $resource = CustomXlsformTemplateResource::class;
+
+    protected ?string $heading = 'Custom Xlsform Templates';
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            CustomOdkTemplatesWidget::class,
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ViewTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ViewTeamCustomXlsformTemplate.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\ViewXlsformTemplate;
+
+class ViewTeamCustomXlsformTemplate extends ViewXlsformTemplate
+{
+    protected static string $resource = CustomXlsformTemplateResource::class;
+}

--- a/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ViewTeamCustomXlsformTemplate.php
+++ b/src/Filament/Resources/TeamCustomXlsformTemplateResource/Pages/ViewTeamCustomXlsformTemplate.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource\Pages;
 
+use Stats4sd\FilamentOdkLink\Filament\Resources\TeamCustomXlsformTemplateResource;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages\ViewXlsformTemplate;
 
 class ViewTeamCustomXlsformTemplate extends ViewXlsformTemplate
 {
-    protected static string $resource = CustomXlsformTemplateResource::class;
+    protected static string $resource = TeamCustomXlsformTemplateResource::class;
 }

--- a/src/Filament/Resources/TeamXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamXlsformTemplateResource.php
@@ -14,6 +14,9 @@ use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use App\Filament\App\Clusters\XlsformsCluster\Resources\XlsformTemplateResource\Pages;
 
+// Use this resource for a panel scoped to a team
+// This resource is for templates available to all platform users
+
 class TeamXlsformTemplateResource extends Resource
 {
     protected static ?string $model = XlsformTemplate::class;

--- a/src/Filament/Resources/TeamXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamXlsformTemplateResource.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Filament\App\Clusters\XlsformsCluster\Resources;
+
+use Filament\Forms;
+use App\Models\Team;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Facades\Filament;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use App\Filament\App\Clusters\XlsformsCluster\Resources\XlsformTemplateResource\Pages;
+
+class TeamXlsformTemplateResource extends Resource
+{
+    protected static ?string $model = XlsformTemplate::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-book-open';
+    protected static ?string $navigationLabel = 'Available ODK Templates';
+
+    protected static bool $isScopedToTenant = false;
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('available', true)
+            ->where(function (Builder $query) {
+                $query->whereHas('owner', function (Builder $subQuery) {
+                    $subQuery->where('id', Filament::getTenant()->id);
+                })
+                    ->orWhere('owner_type', Platform::class);
+            })
+            ->orderBy('owner_type');
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title'),
+                Tables\Columns\IconColumn::make('has_version')
+                    ->label('Deployed?')
+                    ->state(fn(Xlsformtemplate $record) => $record->xlsforms->where('owner_id', Filament::getTenant()->id)->count() > 0)
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('owner_type')
+                    ->label('Owner')
+                    ->badge()
+                    ->getStateUsing(function ($record) {
+                        return $record->owner_type === Platform::class ? 'Platform' : 'Custom';
+                    })
+                    ->color(function ($record) {
+                        return $record->owner_type === Platform::class ? 'gray' : 'success';
+                    })
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\Action::make('deploy')
+                    ->label('Deploy Form')
+                    ->hidden(fn(Xlsformtemplate $record) => $record->xlsforms->where('owner_id', Filament::getTenant()->id)->count() > 0)
+                    ->icon('heroicon-o-cloud-arrow-up')
+                    ->form([
+                        Forms\Components\TextInput::make('title')
+                            ->label('Please give the form a title.')
+                            ->default(fn($record) => Filament::getTenant()->name . ' - ' . $record->title)
+                            ->hint('Note that ODK form titles cannot be longer than 64 characters.')
+                    ])
+                    ->action(function (XlsformTemplate $record, array $data) {
+
+                        $xlsform = $record->xlsforms()->create([
+                            'owner_id' => Filament::getTenant()->id,
+                            'owner_type' => Team::class,
+                            'title' => $data['title'],
+                        ]);
+
+                        // publish the new form
+                        $xlsform->refresh();
+                        $xlsform->publishForm(app()->make(OdkLinkService::class));
+
+
+                    }),
+                Tables\Actions\Action::make('download file')
+                    ->label('Download XLS File')
+                    ->url(fn($record) => $record->getFirstMediaUrl('xlsform_file')),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListXlsformTemplates::route('/'),
+        ];
+    }
+}

--- a/src/Filament/Resources/TeamXlsformTemplateResource.php
+++ b/src/Filament/Resources/TeamXlsformTemplateResource.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\App\Clusters\XlsformsCluster\Resources;
+namespace Stats4sd\FilamentOdkLink\Filament\Resources;
 
 use Filament\Forms;
 use App\Models\Team;

--- a/src/Filament/Resources/TeamXlsformTemplateResource/Pages/ListTeamXlsformTemplates.php
+++ b/src/Filament/Resources/TeamXlsformTemplateResource/Pages/ListTeamXlsformTemplates.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\Resources\CustomXlsformTemplateResource\Pages;
+
+use App\Filament\App\Clusters\XlsformsCluster\Resources\XlsformTemplateResource;
+use App\Filament\App\Clusters\XlsformsCluster\Widgets\AvailableOdkTemplatesWidget;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeamXlsformTemplates extends ListRecords
+{
+    protected static string $resource = XlsformTemplateResource::class;
+
+    protected ?string $heading = 'Available Xlsform Templates';
+
+    protected function getHeaderWidgets(): array
+    {
+        return [
+            AvailableOdkTemplatesWidget::class,
+        ];
+    }
+
+}

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -7,7 +7,6 @@ use Filament\Tables;
 use Filament\Forms\Get;
 use Filament\Forms\Form;
 use Filament\Tables\Table;
-use Filament\Facades\Filament;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Illuminate\Support\HtmlString;
@@ -27,7 +26,6 @@ use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
-use App\Filament\Admin\Resources\XlsformTemplateResource\RelationManagers\XlsformsRelationManager;
 
 class XlsformTemplateResource extends Resource
 {

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -28,6 +28,9 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
 
+// Use this resource for an admin panel
+// This resource is for templates that can be made available to all platform users
+
 class XlsformTemplateResource extends Resource
 {
     protected static ?string $model = XlsformTemplate::class;

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -48,6 +48,29 @@ class XlsformTemplateResource extends Resource
             ]);
     }
 
+    protected function processRecord(XlsformTemplate $record): XlsformTemplate
+    {
+        $odkLinkService = app()->make(OdkLinkService::class);
+
+        $record->owner()->associate(Platform::first());
+        $record->saveQuietly();
+
+        // update form title in xlsfile to match user-given title
+        UpdateXlsformTitleInFile::dispatchSync($record);
+
+        $record->refresh();
+        $record->deployDraft($odkLinkService);
+        $record->getRequiredMedia($odkLinkService);
+
+        // TODO: We need to do the extract section when create and edit
+        $record->extractSections();
+-
+        // mark all xlsforms using this template as not current
+        $record->markAllAsNotCurrent();
+
+        return $record;
+    }
+
     public static function getCreateFields(): array
     {
         return [
@@ -66,6 +89,7 @@ class XlsformTemplateResource extends Resource
                 ->downloadable()
                 ->autofocus()
                 ->required()
+                ->disabledOn(['edit'])
                 ->placeholder(__('File')),
         ];
     }
@@ -254,6 +278,7 @@ class XlsformTemplateResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('title')
                     ->searchable()
+                    ->wrap()
                     ->sortable(),
                 Tables\Columns\ViewColumn::make('required_fixed_media_count')
                     ->label('Fixed Media')
@@ -274,7 +299,19 @@ class XlsformTemplateResource extends Resource
             ])
             ->actions([
                 Tables\Actions\ViewAction::make(),
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\Action::make('update_xlsform_template')
+                    ->label('Replace XLSForm')
+                    ->icon('heroicon-o-document-arrow-up')
+                    ->form(XlsformTemplateResource::getCreateFields())
+                    ->fillForm(function (XlsformTemplate $record) {
+                        return [
+                            'title' => $record->title,
+                        ];
+                    })
+                ->action(function (array $data, XlsformTemplate $record, Get $get) {
+                    $this->processRecord($record);
+                }),
+                Tables\Actions\EditAction::make()->label('Edit Media & Data'),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -11,6 +11,7 @@ use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
 use Illuminate\Support\HtmlString;
 use Filament\Forms\Components\Tabs;
+use Illuminate\Database\Eloquent\Builder;
 use Filament\Infolists\Components\Section;
 use Filament\Infolists\Components\IconEntry;
 use Filament\Infolists\Components\TextEntry;
@@ -32,6 +33,12 @@ class XlsformTemplateResource extends Resource
     protected static ?string $model = XlsformTemplate::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+    
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->where('owner_type', '=', Platform::class);
+    }
 
     public static function form(Form $form): Form
     {

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -2,31 +2,32 @@
 
 namespace Stats4sd\FilamentOdkLink\Filament\Resources;
 
-use App\Filament\Admin\Resources\XlsformTemplateResource\RelationManagers\XlsformsRelationManager;
-use Awcodes\FilamentTableRepeater\Components\TableRepeater;
 use Filament\Forms;
-use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Components\Tabs;
-use Filament\Forms\Form;
+use Filament\Tables;
 use Filament\Forms\Get;
-use Filament\Infolists\Components\IconEntry;
-use Filament\Infolists\Components\RepeatableEntry;
-use Filament\Infolists\Components\Section;
-use Filament\Infolists\Components\TextEntry;
-use Filament\Infolists\Components\ViewEntry;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Filament\Facades\Filament;
 use Filament\Infolists\Infolist;
 use Filament\Resources\Resource;
-use Filament\Tables;
-use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
-use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
-use Stats4sd\FilamentOdkLink\Forms\Components\HtmlBlock;
-use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
+use Filament\Forms\Components\Tabs;
+use Filament\Infolists\Components\Section;
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Components\ViewEntry;
+use Filament\Forms\Components\Actions\Action;
+use Filament\Infolists\Components\RepeatableEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Stats4sd\FilamentOdkLink\Forms\Components\HtmlBlock;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
+use Awcodes\FilamentTableRepeater\Components\TableRepeater;
+use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
-use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
+use App\Filament\Admin\Resources\XlsformTemplateResource\RelationManagers\XlsformsRelationManager;
 
 class XlsformTemplateResource extends Resource
 {
@@ -54,9 +55,6 @@ class XlsformTemplateResource extends Resource
     public static function processRecord(XlsformTemplate $record): XlsformTemplate
     {
         $odkLinkService = app()->make(OdkLinkService::class);
-
-        $record->owner()->associate(Platform::first());
-        $record->saveQuietly();
 
         // update form title in xlsfile to match user-given title
         UpdateXlsformTitleInFile::dispatchSync($record);

--- a/src/Filament/Resources/XlsformTemplateResource.php
+++ b/src/Filament/Resources/XlsformTemplateResource.php
@@ -21,9 +21,12 @@ use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
 use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
 use Stats4sd\FilamentOdkLink\Forms\Components\HtmlBlock;
+use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplateSection;
+use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 
 class XlsformTemplateResource extends Resource
 {
@@ -48,7 +51,7 @@ class XlsformTemplateResource extends Resource
             ]);
     }
 
-    protected function processRecord(XlsformTemplate $record): XlsformTemplate
+    public static function processRecord(XlsformTemplate $record): XlsformTemplate
     {
         $odkLinkService = app()->make(OdkLinkService::class);
 
@@ -79,6 +82,7 @@ class XlsformTemplateResource extends Resource
                 ->required()
                 ->maxLength(64)
                 ->placeholder(__('Title'))
+                ->disabledOn(['edit'])
                 ->default(function () {
                     // get the title from url if it exists in the query string
                     return request()?->query('title');
@@ -302,14 +306,14 @@ class XlsformTemplateResource extends Resource
                 Tables\Actions\Action::make('update_xlsform_template')
                     ->label('Replace XLSForm')
                     ->icon('heroicon-o-document-arrow-up')
-                    ->form(XlsformTemplateResource::getCreateFields())
+                    ->form(self::getCreateFields())
                     ->fillForm(function (XlsformTemplate $record) {
                         return [
                             'title' => $record->title,
                         ];
                     })
-                ->action(function (array $data, XlsformTemplate $record, Get $get) {
-                    $this->processRecord($record);
+                ->action(function (array $data, XlsformTemplate $record) {
+                    XlsformTemplateResource::processRecord($record);
                 }),
                 Tables\Actions\EditAction::make()->label('Edit Media & Data'),
             ])

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
@@ -2,18 +2,19 @@
 
 namespace Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource\Pages;
 
+use Filament\Forms\Get;
+use Filament\Forms\Form;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\Wizard;
 use Filament\Forms\Components\Wizard\Step;
-use Filament\Forms\Form;
-use Filament\Forms\Get;
 use Filament\Resources\Pages\CreateRecord;
-use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Http\Client\RequestException;
-use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource;
-use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Platform;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Stats4sd\FilamentOdkLink\Jobs\UpdateXlsformTitleInFile;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Stats4sd\FilamentOdkLink\Filament\Resources\XlsformTemplateResource;
 
 class CreateXlsformTemplate extends CreateRecord
 {
@@ -86,8 +87,14 @@ class CreateXlsformTemplate extends CreateRecord
     {
         $odkLinkService = app()->make(OdkLinkService::class);
 
-        $record->owner()->associate(Platform::first());
-        $record->saveQuietly();
+        if (is_null(Filament::getTenant())) {
+            $record->owner()->associate(Platform::first());
+            $record->saveQuietly();
+        }
+        else {
+            $record->owner()->associate(Filament::getTenant());
+            $record->saveQuietly();
+        }
 
         // update form title in xlsfile to match user-given title
         UpdateXlsformTitleInFile::dispatchSync($record);

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
@@ -24,8 +24,8 @@ class ViewXlsformTemplate extends ViewRecord
     {
         return [
             Actions\Action::make('update_xlsform_template')
-                ->label('Update XLSForm Template')
-                ->icon('heroicon-o-pencil')
+                ->label('Replace XLSForm')
+                ->icon('heroicon-o-document-arrow-up')
                 ->form(XlsformTemplateResource::getCreateFields())
                 ->fillForm(fn() => [
                     'title' => self::getRecord()->title,
@@ -33,7 +33,9 @@ class ViewXlsformTemplate extends ViewRecord
                 ->action(function (array $data, XlsformTemplate $record, Get $get) {
                     $this->processRecord($record);
                 }),
-            Actions\EditAction::make(),
+            Actions\EditAction::make()
+                ->icon('heroicon-o-pencil-square')
+                ->label('Edit Media & Data'),
             Actions\DeleteAction::make(),
         ];
     }

--- a/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
+++ b/src/Filament/Resources/XlsformTemplateResource/Pages/ViewXlsformTemplate.php
@@ -31,7 +31,7 @@ class ViewXlsformTemplate extends ViewRecord
                     'title' => self::getRecord()->title,
                 ])
                 ->action(function (array $data, XlsformTemplate $record, Get $get) {
-                    $this->processRecord($record);
+                    XlsformTemplateResource::processRecord($record);
                 }),
             Actions\EditAction::make()
                 ->icon('heroicon-o-pencil-square')
@@ -39,29 +39,5 @@ class ViewXlsformTemplate extends ViewRecord
             Actions\DeleteAction::make(),
         ];
     }
-
-    protected function processRecord(XlsformTemplate $record): XlsformTemplate
-    {
-        $odkLinkService = app()->make(OdkLinkService::class);
-
-        $record->owner()->associate(Platform::first());
-        $record->saveQuietly();
-
-        // update form title in xlsfile to match user-given title
-        UpdateXlsformTitleInFile::dispatchSync($record);
-
-        $record->refresh();
-        $record->deployDraft($odkLinkService);
-        $record->getRequiredMedia($odkLinkService);
-
-        // TODO: We need to do the extract section when create and edit
-        $record->extractSections();
--
-        // mark all xlsforms using this template as not current
-        $record->markAllAsNotCurrent();
-
-        return $record;
-    }
-
 
 }


### PR DESCRIPTION
This PR:
- improves actions for repalcing form/editing media on xlsform templates table and view pages 
- enables teams to create custom xlsform templates with a resource for the team scoped panel and a resource for the admin panel
- filters the xlsform templates resource to only show templates available to all
- adds a xlsform templates resource to be used on a team scoped panel