### PR TITLE
Temp fix for namespace clash on media

### DIFF
--- a/src/Models/OdkLink/Xlsform.php
+++ b/src/Models/OdkLink/Xlsform.php
@@ -83,7 +83,7 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
     {
         return new Attribute(
             get: function () {
-                if(!$this->has_latest_template || !$this->has_latest_media) {
+                if (!$this->has_latest_template || !$this->has_latest_media) {
                     return 'UPDATES AVAILABLE';
                 }
                 if ($this->is_active) {
@@ -152,7 +152,21 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
     public function syncWithTemplate(): void
     {
         // copy the xlsfile from the template;
-        $this->xlsformTemplate->getFirstMedia('xlsform_file')?->copy($this, 'xlsform_file');
+
+        // TEMP fix for namespace clashes
+        // TODO - find a permanent fix for this
+        if (!$xlsfile = $this->xlsformTemplate->getFirstMedia('xlsform_file')) {
+
+            // check if \App\Models\XlsformTemplate exists
+            if (class_exists('\App\Models\XlsformTemplate')) {
+
+                $xlsfile = \App\Models\XlsformTemplate::find($this->xlsformTemplate->id)
+                    ->getFirstMedia('xlsform_file');
+
+            }
+        }
+
+        $xlsfile->copy($this, 'xlsform_file');
         $this->saveQuietly();
 
         // update form title and ID in the file itself (ODK Central looks for these values in the XLS file)
@@ -164,18 +178,21 @@ class Xlsform extends Model implements HasMedia, WithXlsFormDrafts
         $this->saveQuietly();
     }
 
-    public function getSubmissions(): int
+    public
+    function getSubmissions(): int
     {
         return app()->make(OdkLinkService::class)->getSubmissions($this);
     }
 
-    public function getLiveSubmissionCount(): int
+    public
+    function getLiveSubmissionCount(): int
     {
         return app()->make(OdkLinkService::class)->getSubmissionCount($this);
     }
 
     // Get the live submissions count from ODK Central
-    public function liveSubmissionsCount(): Attribute
+    public
+    function liveSubmissionsCount(): Attribute
     {
         return new Attribute(
             get: function () {


### PR DESCRIPTION
This temporary fix is intended as a short-term fix for https://github.com/stats4sd/holpa-platform/issues/41.

The longer term fix is to tidy up how we organise our classes between app and package and consolidate all our ODK app components. 