### PR TITLE
let devs assign data models as primary data subjects:

### DIFF
--- a/database/migrations/010_create_submissions_table.php
+++ b/database/migrations/010_create_submissions_table.php
@@ -15,6 +15,7 @@ return new class extends Migration {
             $table->string('odk_id')->unique()->comment('The ODK Central ID of the submission.');
             $table->string('odk_latest_version_id')->nullable()->comment('If the submission has been edited on ODK, this is the latest version ID.');
             $table->foreignId('xlsform_version_id')->constrained('xlsform_versions');
+            $table->nullableMorphs('primary_data_subject', 'subject');
             $table->timestamp('submitted_at');
             $table->string('submitted_by')->nullable();
             $table->string('updated_by')->nullable();

--- a/src/Models/OdkLink/Interfaces/IsCreatedFromOdkSubmissions.php
+++ b/src/Models/OdkLink/Interfaces/IsCreatedFromOdkSubmissions.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Stats4sd\FilamentOdkLink\Models\OdkLink\Traits;
+namespace Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces;
 
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Entity;
 

--- a/src/Models/OdkLink/Interfaces/IsPrimaryDataSubject.php
+++ b/src/Models/OdkLink/Interfaces/IsPrimaryDataSubject.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+/**
+ * @phpstan-require-extends Model
+ */
+interface IsPrimaryDataSubject
+{
+    public function submissions(): MorphMany;
+}

--- a/src/Models/OdkLink/Submission.php
+++ b/src/Models/OdkLink/Submission.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Routing\Redirector;
@@ -17,6 +18,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Session;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\IsPrimaryDataSubject;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 use Stats4sd\FilamentOdkLink\Services\HelperService;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
@@ -89,6 +91,12 @@ class Submission extends Model implements HasMedia
     public function scopeOnlyRealData(Builder $query): void
     {
         $query->where('test_data', false);
+    }
+
+    /** @return MorphTo<Model, $this> */
+    public function primaryDataSubject(): MorphTo
+    {
+        return $this->morphTo();
     }
 
     // $this->entries is an array of every Model entry created as a result of processing this submission.

--- a/src/Models/OdkLink/Traits/HasSubmissions.php
+++ b/src/Models/OdkLink/Traits/HasSubmissions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Models\OdkLink\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
+
+/** @phpstan-require-extends Model */
+trait HasSubmissions
+{
+    /** @return MorphMany<Submission, $this> */
+    public function submissions(): MorphMany
+    {
+        return $this->morphMany(Submission::class, 'data_subject_id');
+    }
+}


### PR DESCRIPTION
This PR adds the ability for devs to mark data models as "data subjects", and assign submissions to them.

An example is in HOLPA, where the `Farm`  model is a data subject. The data processing there links submissions to farms, so that you can monitor progress of a survey across different locations.

The intention here is for this to be quite extensible and flexible, so we're using morph relationships, and a Trait and Interface that can be added to any number of data models in the main app. 