### PR TITLE
fix for issue where xlsform-template is saved before it's ready

### DIFF
--- a/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
+++ b/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
@@ -52,6 +52,8 @@ class CreateXlsformTemplate extends CreateRecord
 
                     try {
 
+                        ray('hi');
+
                         // wait to trigger the saved event until the xlsform file is attached.
                         /** @var XlsformTemplate $xlsformTemplate */
                         $xlsformTemplate = XlsformTemplate::make([
@@ -59,9 +61,16 @@ class CreateXlsformTemplate extends CreateRecord
                             'newXlsfile' => collect($get('newXlsfile'))->first(),
                         ]);
 
+                        ray('ok');
+
                         $xlsformTemplate->owner()->associate(Platform::first());
 
+                        ray('do');
+
+
                         $xlsformTemplate = $xlsformTemplate->testOnOdkCentral();
+
+                        ray('you');
 
                         $xlsformTemplate->save();
 

--- a/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
+++ b/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
@@ -52,8 +52,6 @@ class CreateXlsformTemplate extends CreateRecord
 
                     try {
 
-                        ray('hi');
-
                         // wait to trigger the saved event until the xlsform file is attached.
                         /** @var XlsformTemplate $xlsformTemplate */
                         $xlsformTemplate = XlsformTemplate::make([
@@ -61,16 +59,9 @@ class CreateXlsformTemplate extends CreateRecord
                             'newXlsfile' => collect($get('newXlsfile'))->first(),
                         ]);
 
-                        ray('ok');
-
                         $xlsformTemplate->owner()->associate(Platform::first());
 
-                        ray('do');
-
-
                         $xlsformTemplate = $xlsformTemplate->testOnOdkCentral();
-
-                        ray('you');
 
                         $xlsformTemplate->save();
 

--- a/src/Jobs/XlsformDeployment/DeployDraftXlsformToOdkCentral.php
+++ b/src/Jobs/XlsformDeployment/DeployDraftXlsformToOdkCentral.php
@@ -33,17 +33,13 @@ class DeployDraftXlsformToOdkCentral implements ShouldQueue
 
         $odkLinkService = app()->make(OdkLinkService::class);
 
-        $odkXlsFormDetails = $odkLinkService->createDraftForm($this->xlsform, $this->xlsform->xlsfile->getPath(), $this->withMedia);
+        $this->xlsform = $odkLinkService->createDraftForm($this->xlsform, $this->xlsform->xlsfile->getPath(), $this->withMedia);
 
-        $this->xlsform->update([
-            'odk_id' => $odkXlsFormDetails['xmlFormId'],
-            'odk_draft_token' => $odkXlsFormDetails['draftToken'],
-            'odk_version_id' => $odkXlsFormDetails['version'],
-            'has_draft' => true,
-            'enketo_draft_id' => $odkXlsFormDetails['enketoId'],
-            'odk_draft_updated_at' => new Carbon($odkXlsFormDetails['updatedAt']),
-            'needs_update' => false,
-        ]);
+        if($this->xlsform instanceof Xlsform) {
+            $this->xlsform->needs_update = true;
+        }
+
+        $this->xlsform->save();
 
         // only ever keep 1 "draft" version; we don't need to store all iterations of drafts as we don't keep the old submissions either
         $this->xlsform->xlsformVersions()->updateOrCreate(

--- a/src/Models/OdkLink/XlsformTemplate.php
+++ b/src/Models/OdkLink/XlsformTemplate.php
@@ -56,9 +56,18 @@ class XlsformTemplate extends HasXlsformDrafts
             $xlsformTemplate->xlsformModules()->delete();
         });
 
+        static::creating(static function (XlsformTemplate $xlsformTemplate) {
+            ray('woah there');
+        });
+
         static::saving(static function (XlsformTemplate $xlsformTemplate) {
+
+            ray('well hello there');
+            ray($xlsformTemplate->newXlsfile);
             if ($xlsformTemplate->newXlsfile instanceof UploadedFile) {
                 $xlsformTemplate->addMedia($xlsformTemplate->newXlsfile)->toMediaCollection('xlsform_file');
+
+                ray('this is a file;');
 
                 unset($xlsformTemplate->newXlsfile);
 

--- a/src/Models/OdkLink/XlsformTemplate.php
+++ b/src/Models/OdkLink/XlsformTemplate.php
@@ -56,18 +56,10 @@ class XlsformTemplate extends HasXlsformDrafts
             $xlsformTemplate->xlsformModules()->delete();
         });
 
-        static::creating(static function (XlsformTemplate $xlsformTemplate) {
-            ray('woah there');
-        });
-
         static::saving(static function (XlsformTemplate $xlsformTemplate) {
 
-            ray('well hello there');
-            ray($xlsformTemplate->newXlsfile);
             if ($xlsformTemplate->newXlsfile instanceof UploadedFile) {
                 $xlsformTemplate->addMedia($xlsformTemplate->newXlsfile)->toMediaCollection('xlsform_file');
-
-                ray('this is a file;');
 
                 unset($xlsformTemplate->newXlsfile);
 

--- a/src/Services/OdkLinkServices/OdkFormService.php
+++ b/src/Services/OdkLinkServices/OdkFormService.php
@@ -28,7 +28,7 @@ trait OdkFormService
      * @throws RequestException|ConnectionException
      * @throws \Exception
      */
-    public function createDraftForm(HasXlsformDrafts $xlsform, string $filePath, bool $withMedia = true): array
+    public function createDraftForm(HasXlsformDrafts $xlsform, string $filePath, bool $withMedia = true): HasXlsformDrafts
     {
 
         $token = $this->authenticate();
@@ -76,7 +76,16 @@ trait OdkFormService
             $this->uploadMediaFileAttachments($xlsform);
         }
 
-        return $this->getXlsformDraftDetails($xlsform);
+        $draftDetails = $this->getXlsformDraftDetails($xlsform);
+        $xlsform->odk_id = $draftDetails['xmlFormId'];
+        $xlsform->odk_draft_token = $draftDetails['draftToken'];
+        $xlsform->odk_version_id = $draftDetails['version'];
+        $xlsform->has_draft = true;
+        $xlsform->enketo_draft_id = $draftDetails['enketoId'];
+        $xlsform->odk_draft_updated_at = new Carbon($draftDetails['updatedAt']);
+
+
+        return $xlsform;
 
     }
 
@@ -122,7 +131,6 @@ trait OdkFormService
         })->toArray();
 
         $xlsform->schema = $schema;
-        $xlsform->saveQuietly();
 
         return $xlsform;
     }


### PR DESCRIPTION
Fixes #79, by removing the `saveQuietly()` from the deploy draft process. 

Now, the OdkLinkService's `createDraftForm()` function returns the instance of the XlsformTemplate or Xlsform, and so which-ever place has called that function can handle saving the model to the database.