### PR TITLE
Duplicated default locales + Initial Deployment issues

### DIFF
--- a/src/Exports/XlsformExport/ExportsXlsformContent.php
+++ b/src/Exports/XlsformExport/ExportsXlsformContent.php
@@ -3,6 +3,7 @@
 namespace Stats4sd\FilamentOdkLink\Exports\XlsformExport;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceListEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\SurveyRow;
@@ -13,7 +14,13 @@ trait ExportsXlsformContent
 
     public function mapPropertiesToPropertyHeadings(SurveyRow|ChoiceListEntry $entry): array
     {
-        return $this->propertyHeadings->mapWithKeys(fn(string $heading) => [$heading => $entry->properties[$heading] ?? null])->toArray();
+        return $this->propertyHeadings->mapWithKeys(function (string $heading) use ($entry) {
+
+            // formatting for media:: headings
+            $key = Str::replace('::', '', $heading);
+
+            return [$heading => $entry->properties[$key] ?? null];
+        })->toArray();
     }
 
     public function getLanguageStringHeaders(string $string): Collection
@@ -67,6 +74,7 @@ trait ExportsXlsformContent
             ->filter()
             ->map(fn($heading) => collect(json_decode($heading, true)))
             ->flatten()
+            ->map(fn($heading) => $this->expandMediaColumnHeaders($heading))
             ->unique();
     }
 

--- a/src/Imports/XlsformTemplate/XlsformTemplateLanguageStringImport.php
+++ b/src/Imports/XlsformTemplate/XlsformTemplateLanguageStringImport.php
@@ -134,7 +134,6 @@ class XlsformTemplateLanguageStringImport implements SkipsEmptyRows, ToModel, Wi
         // make sure the default locale for this language exists
         $locale = $this->language->locales()->firstOrCreate([
             'is_default' => true,
-            'description' => $this->language->name . '(Default)'
         ]);
 
         return new LanguageString([

--- a/src/Models/OdkLink/Xlsform.php
+++ b/src/Models/OdkLink/Xlsform.php
@@ -47,7 +47,10 @@ class Xlsform extends HasXlsformDrafts implements HasMedia
     {
         // when the model is created;
         static::saved(static function (self $xlsform) {
-            $xlsform->syncWithTemplate();
+
+            if (!$xlsform->has_latest_template) {
+                $xlsform->syncWithTemplate();
+            }
 
             // check if the needs_up date was updated from true to false
             if ($xlsform->wasChanged('draft_needs_update') && !$xlsform->draft_needs_update) {
@@ -65,6 +68,7 @@ class Xlsform extends HasXlsformDrafts implements HasMedia
         });
 
         static::created(static function (self $xlsform) {
+            $xlsform->syncWithTemplate();
             $xlsform->deployDraft();
         });
 

--- a/src/Models/OdkLink/XlsformLanguages/Locale.php
+++ b/src/Models/OdkLink/XlsformLanguages/Locale.php
@@ -2,11 +2,13 @@
 
 namespace Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformLanguages;
 
+use Illuminate\Database\Eloquent\Collection;
 use Spatie\MediaLibrary\HasMedia;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 use Stats4sd\FilamentOdkLink\Services\HelperService;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -26,6 +28,32 @@ class Locale extends Model implements HasMedia
     protected $appends = [
         'language_label',
     ];
+
+    protected static function booted(): void
+    {
+        static::created(function (self $locale) {
+
+            // if the locale is default, check all teams to see if they are linked to the language and do not yet have a locale
+
+            /** @var Collection<WithXlsforms> $owners */
+            $owners = config('filament-odk-link.models.team_model')::all();
+
+            $owners->each(function (WithXlsforms $owner) use ($locale) {
+                if (
+                    // if the owner is linked to the language
+                    $owner->languages->contains($locale->language) &&
+
+                    // and the owner doesn't have a locale set for that language already
+                    $owner->locales->filter(fn(Locale $l) => $l->language_id === $locale->language_id)->count() === 0
+                ) {
+
+                    // assign the new 'default' locale to that owner/language combo.
+                    $owner->languages()->updateExistingPivot($locale->language_id, ['locale_id' => $locale->id]);
+                }
+            });
+
+        });
+    }
 
     public function registerMediaCollections(): void
     {
@@ -64,6 +92,13 @@ class Locale extends Model implements HasMedia
         return $this->belongsTo(config('filament-odk-link.models.team_model'), 'creator_id');
     }
 
+    public function owners(): BelongsToMany
+    {
+        return $this->BelongsToMany
+        (config('filament-odk-link.models.team_model'), 'language_owner', 'locale_id', 'owner_id')
+            ->withPivot(['langauge_id']);
+    }
+
     /** @return Attribute<string, never> */
     protected function languageLabel(): Attribute
     {
@@ -90,10 +125,10 @@ class Locale extends Model implements HasMedia
                 $moduleVersions = $this->xlsformModuleVersions;
                 $allModuleVersions = $xlsforms
                     ->map(
-                        fn (Xlsform $xlsform) => $xlsform
+                        fn(Xlsform $xlsform) => $xlsform
                             ->xlsformTemplate
                             ->xlsformModules
-                            ->map(fn (XlsformModule $xlsformModule) => $xlsformModule->defaultXlsformVersion)
+                            ->map(fn(XlsformModule $xlsformModule) => $xlsformModule->defaultXlsformVersion)
                     )->flatten();
 
                 if ($moduleVersions->count() === 0) {
@@ -108,7 +143,7 @@ class Locale extends Model implements HasMedia
                  * Ignoring because phpstan/larastan doesn't yet support easy handling of pivot values, and the workaround seem not worth it here.
                  * https://github.com/larastan/larastan/issues/1774
                  */
-                if ($moduleVersions->every(fn ($moduleVersion) => ! $moduleVersion->pivot->needs_update && $moduleVersion->pivot->has_language_strings)) {
+                if ($moduleVersions->every(fn($moduleVersion) => !$moduleVersion->pivot->needs_update && $moduleVersion->pivot->has_language_strings)) {
                     return 'Ready for use';
                 }
 
@@ -121,7 +156,7 @@ class Locale extends Model implements HasMedia
     protected function odkLabel(): Attribute
     {
         return new Attribute(
-            get: fn () => $this->language->name . ' (' . $this->language->iso_alpha2 . ')',
+            get: fn() => $this->language->name . ' (' . $this->language->iso_alpha2 . ')',
         );
     }
 
@@ -129,7 +164,7 @@ class Locale extends Model implements HasMedia
     protected function isEditable(): Attribute
     {
         return new Attribute(
-            get: fn () => $this->creator?->getKey() === HelperService::getCurrentOwner()->getKey(),
+            get: fn() => $this->creator?->getKey() === HelperService::getCurrentOwner()->getKey(),
         );
     }
 
@@ -139,7 +174,7 @@ class Locale extends Model implements HasMedia
     protected function isEditing(): Attribute
     {
         return new Attribute(
-            get: fn () => $this->is_editable && $this->status !== 'Ready for use',
+            get: fn() => $this->is_editable && $this->status !== 'Ready for use',
         );
     }
 }

--- a/src/Models/OdkLink/XlsformTemplate.php
+++ b/src/Models/OdkLink/XlsformTemplate.php
@@ -28,6 +28,7 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\Abstracts\HasXlsformDrafts;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsformDrafts;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsforms;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Traits\HasUploadedXlsformFile;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformLanguages\Locale;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
 use Stats4sd\FilamentOdkLink\Services\UpdateXlsformTitleInFile;
 use Staudenmeir\EloquentHasManyDeep\HasManyDeep;
@@ -292,7 +293,7 @@ class XlsformTemplate extends HasXlsformDrafts
     // Split up language strings into 2 relationships as there are 2 paths between xlsformtemplates and language strings
 
     /** @return HasManyDeep<LanguageString, $this> */
-public function surveyLanguageStrings(): HasManyDeep
+    public function surveyLanguageStrings(): HasManyDeep
     {
         return $this->hasManyDeep(
             LanguageString::class,


### PR DESCRIPTION
Fixes issues from HOLPA: 
- [Intial pilot forms not publishing/appearing in ODK after scanning QR code](https://github.com/stats4sd/holpa-platform/issues/270)

When a new Xlsform is created, it is deployed via the event listener "created" function on the model. This was previously happening _before_  the `->syncWithTemplate()` function (that happens when an Xlsform is saved), so at the point of deployment, the Xlsform had 0 linked XlsformModuleVersions - and so was empty. 

This PR fixes that by running `->syncWithTemplate()` before `deployDraft()` as soon as the form is created. It also fixes an issue with the XlsformExport, in the case where a form has "media::image" instead of a language-specific media image, the heading was not being formatted correctly, causing the form to miss all the content in that column. 

- [Language Strings are not imported correctly from xlsform template in live site](https://github.com/stats4sd/holpa-platform/issues/272)
- [Live site - translation template doesn't have original text column](https://github.com/stats4sd/holpa-platform/issues/271)

This issue, and a variety of strange behaviour was being caused because there were 2 separate places where a default locale was being created during the import of an XlsformTemplate. 

-> Within the `LinkModuleVersionToLocales` import (lines 42 - 49; if a `$language->defaultLocale` didn't exist, a locale was created with `is_default = true` and a null description. 
-> Within the `XlsformTemplateLanguageStringImport` import, lines 135-137, a firstOrCreate() function was checking for a locale with `is_deafult = true` and a description of `($this->language->name . '(Default)'`. 

As the first locale was created with a null description, this resulted in 2 `default` locales being created, which caused various issues with assigning locales to language strings.


