### PR TITLE
Module localisation types

### DIFF
--- a/src/Imports/XlsformTemplate/XlsformModuleImport.php
+++ b/src/Imports/XlsformTemplate/XlsformModuleImport.php
@@ -67,9 +67,6 @@ class XlsformModuleImport implements SkipsEmptyRows, ToCollection, WithHeadingRo
             ->each(function ($row, $key) use (&$order) {
 
                 // make sure xlsformModule exists
-
-                ray($row);
-
                 /** @var XlsformModule $module */
                 $module = $this->xlsformTemplate->xlsformModules()->updateOrCreate([
                     'name' => $key,

--- a/src/Imports/XlsformTemplate/XlsformModuleImport.php
+++ b/src/Imports/XlsformTemplate/XlsformModuleImport.php
@@ -68,13 +68,22 @@ class XlsformModuleImport implements SkipsEmptyRows, ToCollection, WithHeadingRo
 
                 // make sure xlsformModule exists
 
+                ray($row);
+
                 /** @var XlsformModule $module */
                 $module = $this->xlsformTemplate->xlsformModules()->updateOrCreate([
                     'name' => $key,
                 ],[
                     'label' => $key,
                     'default_order' => $order,
+                    'can_be_extended' => $row[0]['localisable_module'] == 'extend' ?? false,
+                    'can_be_replaced' => $row[0]['localisable_module'] == 'replace' ?? false,
                 ]);
+
+                // if the module can be extended, it means we need to leave space for a 'localised_$name' module directly after it, so increment $order by 2.
+                if($module->can_be_extended)  {
+                    $order++;
+                }
 
                 $order++;
             });

--- a/src/Models/OdkLink/ChoiceListEntry.php
+++ b/src/Models/OdkLink/ChoiceListEntry.php
@@ -45,8 +45,17 @@ class ChoiceListEntry extends Model implements WithLanguageStrings
             }
         });
 
-        static::deleting(function ($surveyRow) {
-            $surveyRow->languageStrings()->delete();
+        // When a choice list entry is updated, we need to recompile the drafts of any xlsforms that include it.
+        static::saved(function (self $choiceListEntry) {
+            $choiceListEntry->xlsformModuleVersion->xlsforms()->update([
+                'draft_needs_update' => true,
+            ]);
+
+        });
+
+
+        static::deleting(function (self $choiceListEntry) {
+            $choiceListEntry->languageStrings()->delete();
         });
     }
 

--- a/src/Models/OdkLink/SurveyRow.php
+++ b/src/Models/OdkLink/SurveyRow.php
@@ -28,6 +28,14 @@ class SurveyRow extends Model implements WithLanguageStrings
 
     protected static function booted(): void
     {
+
+        // When a survey row is changed, we need to recompile any draft xlsforms that include it.
+        static::saved(function (self $surveyRow) {
+           $surveyRow->xlsformModuleVersion->xlsforms()->update([
+              'draft_needs_update' => true,
+           ]);
+        });
+
         static::deleting(function ($surveyRow) {
             $surveyRow->languageStrings()->delete();
         });
@@ -71,8 +79,6 @@ class SurveyRow extends Model implements WithLanguageStrings
 
         return $type;
     }
-
-
 
 
 }

--- a/src/Models/OdkLink/Xlsform.php
+++ b/src/Models/OdkLink/Xlsform.php
@@ -202,16 +202,25 @@ class Xlsform extends HasXlsformDrafts implements HasMedia
     public function syncWithTemplate(): void
     {
 
-        $countModules = 1;
-
         // check through the template modules; If this form is missing any, add the default version
         $this->xlsformTemplate->xlsformModules
             ->sortBy('default_order')
+
+            // check for modules where the module version is not _already_ linked to this form (to avoid resetting custom ordering)
             ->filter(fn(XlsformModule $module) => $this->xlsformModuleVersions->doesntContain('xlsform_module_id', $module->id))
             ->each(function (XlsformModule $xlsformModule) use (&$countModules) {
-                $this->xlsformModuleVersions()->attach($xlsformModule->defaultXlsformVersion, ['order' => $countModules]);
+                $this->xlsformModuleVersions()->attach($xlsformModule->defaultXlsformVersion, ['order' => $xlsformModule->default_order]);
 
-                $countModules++;
+                // If the XlsformModule `can_be_extended` add a 'local' version of the module immediately after it
+                if ($xlsformModule->can_be_extended) {
+                    $localModuleVersion = XlsformModuleVersion::firstOrCreate([
+                        'owner_id' => $this->owner->id,
+                        'name' => 'Local ' . $xlsformModule->name,
+                    ]);
+
+                    $this->xlsformModuleVersions()->sync([$localModuleVersion->id => ['order' => $xlsformModule->default_order + 1]], detaching: false);
+                }
+
             });
 
 

--- a/src/Models/OdkLink/XlsformModule.php
+++ b/src/Models/OdkLink/XlsformModule.php
@@ -20,6 +20,14 @@ class XlsformModule extends Model
 
     protected $table = 'xlsform_modules';
 
+    protected function casts(): array
+    {
+        return [
+            'can_be_extended' => 'boolean',
+            'can_be_replaced' => 'boolean',
+        ];
+    }
+
     protected static function booted(): void
     {
 
@@ -31,6 +39,7 @@ class XlsformModule extends Model
                 'name' => 'Global ' . $module->name, // hard-code name for now
                 'is_default' => true,
             ]);
+
         });
 
     }


### PR DESCRIPTION
Adds feature where XlsformModules can be marked as "can_be_extended":

- In an XlsformTemplate file, add "extend" to the "module_localisable" column for at least the first row of a module. 
- When importing the file + creating modules, space in the ordering is left for a "local_{$xlsformModule->name}" module version.
- When creating an Xlsform, a new XlsformModuleVersion is created -> called "local_${xlsformModule->name}", and placed in the order immediately after the 'default' $xlsformModuleVersion. 

This way, teams can add any set of questions to the local module version, and they will be included automatically into the form just after the questions from the default / global module. 


