### PR TITLE
Handle Non-Existed Language in Xlsform Template

### DIFF
--- a/src/Services/XlsformTranslationHelper.php
+++ b/src/Services/XlsformTranslationHelper.php
@@ -22,20 +22,65 @@ class XlsformTranslationHelper
 
     public function getLanguageStringTypeFromColumnHeader(string $columnHeader): LanguageStringType
     {
+        logger('XlsformTranslationHelper.getLanguageStringTypeFromColumnHeader()...');
+
         preg_match($this->getRegexPattern(), $columnHeader, $matches);
 
-        return $this->languageStringTypes->firstWhere('name', $matches[1]);
+        logger('matches:');
+        logger($matches);
+        logger(count($matches));
+
+        // return $this->languageStringTypes->firstWhere('name', $matches[1]);
+
+        if (count($matches) != 0) {
+            logger('Locale found');
+            $result = $this->languageStringTypes->firstWhere('name', $matches[1]);
+        } else {
+            logger('No locale found, always assume language string type is "label"');
+            $result = $this->languageStringTypes->first();
+        }
+
+        return $result;
     }
 
     public function getLanguageFromColumnHeader(string $columnHeader): Language
     {
+        logger('XlsformTranslationHelper.getLanguageFromColumnHeader()...');
+
+        // TODO: check what language found from column header, return English if no language found from column heade4r
+
         preg_match($this->getRegexPattern(), $columnHeader, $matches);
 
-        return $this->languages->firstWhere('iso_alpha2', $matches[3]);
+        logger('matches:');
+        logger($matches);
+        logger(count($matches));
+
+        // return $this->languages->firstWhere('iso_alpha2', $matches[3]);
+
+        logger($this->languages);
+        logger($this->languages->first());
+
+        if (count($matches) != 0) {
+            logger('Locale found');
+            $result = $this->languages->firstWhere('iso_alpha2', $matches[3]);
+        } else {
+            logger('No locale found, use English as default locale');
+            // $result = Language::where('iso_alpha2', 'en')->get();
+            $result = $this->languages->first();
+        }
+
+        logger($result);
+
+        return $result;
     }
 
     public function getTranslatableColumnsFromFile(string $filePath): Collection
     {
+        logger('XlsformTranslationHelper.getTranslatableColumnsFromFile()...');
+
+        // TODO: check if any translatable columns found, with class XlsformTemplateHeadingRowImport
+        // if translatable columns is null, check again without matching locale two chars short code 
+
         // return a keyed collection for survey + choices headings.
         return (new XlsformTemplateHeadingRowImport)
             ->toCollection($filePath)
@@ -48,7 +93,9 @@ class XlsformTranslationHelper
 
     private function isTranslatableColumn(string $columnHeader): bool
     {
-        return preg_match($this->getRegexPattern(), $columnHeader);
+        // return preg_match($this->getRegexPattern(), $columnHeader);
+
+        return true;
     }
 
     public function getRegexPattern(): string
@@ -57,5 +104,49 @@ class XlsformTranslationHelper
         $languageCodes = $this->languages->pluck('iso_alpha2')->toArray();
 
         return '/^(' . implode('|', $typeNames) . '):?:?([A-z]+)[_\s]\(?(' . implode('|', $languageCodes) . ')\)?$/';
+    }
+
+
+/* ********** */
+
+
+    public function getLanguageFromColumnHeaderWithoutLanguage(string $columnHeader): Language
+    {
+        // preg_match($this->getRegexPatternWithoutLanguage(), $columnHeader, $matches);
+
+        // return $this->languages->firstWhere('iso_alpha2', $matches[3]);
+
+        // always return English
+        // $defaultLanguage = Language::find('iso_alpha2', 'en')->get();
+        $defaultLanguage = Language::find('iso_alpha2', 'en');
+
+        return $defaultLanguage;
+
+    }
+
+    public function getTranslatableColumnsWithoutLanguageFromFile(string $filePath): Collection
+    {
+        logger('XlsformTranslationHelper.getTranslatableColumnsWithoutLanguageFromFile()...');
+
+        // return a keyed collection for survey + choices headings.
+        return (new XlsformTemplateHeadingRowImport)
+            ->toCollection($filePath)
+            ->mapWithKeys(fn($value, $key) => [
+                $key => $value[0]
+                    ->map(fn($columnHeader) => self::isTranslatableColumnWithoutLanguage($columnHeader) ? $columnHeader : null)
+                    ->filter(),
+            ]);
+    }
+
+    private function isTranslatableColumnWithoutLanguage(string $columnHeader): bool
+    {
+        return preg_match($this->getRegexPatternWithoutLanguage(), $columnHeader);
+    }
+
+    public function getRegexPatternWithoutLanguage(): string
+    {
+        $typeNames = $this->languageStringTypes->pluck('name')->toArray();
+
+        return '/^(' . implode('|', $typeNames) . '):?:?([A-z]+)[_\s]?$/';
     }
 }


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/filament-odk-link/issues/59 and fix https://github.com/stats4sd/apni-research/issues/38

It is not ready for review. It is submitted for progress update.

---

I spent some time to trace the program flow and did some testing. I used the simplest ODK form for testing:
1. With the original column heading, e.g. label::English
2. With the modified column heading, e.g. label::English (en)

My first attempt is to check if the language is not specified in column header, rather than a non existed language specified.

My direction for program change is to check if no language found in column header, that means the original regular expression failed. I will do another checking with a new regular expression that does not check for the two chars language code.

Now I reached a point that no error occurred, but also no language_strings record created yet.

By the way, I started to re-think how should we handle this situation....

---

The original regular expression works well for a column header with correct format:
<img width="1623" height="497" alt="image" src="https://github.com/user-attachments/assets/d2673f1f-8f27-425f-9c49-208766f507a1" />

If the original regular expression failed, I try another regular expression that does not look for two chars language code:
<img width="1623" height="497" alt="image" src="https://github.com/user-attachments/assets/f08df66d-6df9-40fc-a457-5f77fa7a2308" />

However, if column header contains a non-existed language code, e.g. zz. Both the original and new regular expression will be failed to parse it.
<img width="1623" height="497" alt="image" src="https://github.com/user-attachments/assets/29aaec85-cc4f-463c-8edb-a05287e29309" />

<img width="1623" height="497" alt="image" src="https://github.com/user-attachments/assets/10a8c8a0-ee35-4fe1-8c99-17c30cfdabec" />

---

@dave-mills - Some questions appeared in my mind...

1. Should I define the third regular expression to check for non-existed language code?
2. Is it possible to modify the original regular expression so that it works no matter language code is found in column header or not. (But the purpose of using regular expression is to check if things are in the pre-defined format...)
3. If there is a non-existed language defined in excel file column header, we imported it as default language English. How will user use the imported "English" language strings? User will notice they are not English wordings and corrective actions will be taken. E.g. Contact Super Admin to add a new language in application, upload the xlsform template again to make everything created properly. The initially imported "English" language_strings are unlikely to be used.
4. If the application can detect there is a non-existed language, can we simply fail the validation and show error message to advise corrective action?