### PR TITLE
Add Xlsform Template Custom Validation for Language

### DIFF
--- a/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
+++ b/src/Filament/OdkAdmin/Resources/XlsformTemplateResource/Pages/CreateXlsformTemplate.php
@@ -49,6 +49,7 @@ class CreateXlsformTemplate extends CreateRecord
                         // find the full file path of the uploaded xlsform template excel file
                         $pathName = collect($get('newXlsfile'))->first()->getPathName();
 
+
                         // call helper function to perform custom validation for type or_other
                         $errorMessages = XlsformValidationHelper::validateTypeOrOther($pathName);
 
@@ -60,9 +61,9 @@ class CreateXlsformTemplate extends CreateRecord
                             foreach ($errorMessages as $errorMessage) {
                                 $i++;
 
-                                Notification::make('xlsform_template_validation_failed_' . $i)
-                                    ->title('XLSForm Template Not Saved')
-                                    ->body('XLSForm Template validation failed. Error: '. $errorMessage)
+                                Notification::make('xlsform_template_odk_variable_type_validation_failed_' . $i)
+                                    ->title('XLSForm Template ODK variable type validation failed')
+                                    ->body('Error: '. $errorMessage)
                                     ->danger()
                                     ->persistent()
                                     ->send();
@@ -73,8 +74,28 @@ class CreateXlsformTemplate extends CreateRecord
                         }
 
 
-                        // TODO: call helper function to perform custom validation for unspecified language or non-existed language
+                        // call helper function to perform custom validation for unspecified language or non-existed language
+                        $errorMessages = XlsformValidationHelper::validateColumnHeadersWithLanguageString($pathName);
 
+                        // show error messages if any
+                        if ($errorMessages->count() > 0) {
+                            $i = 0;
+
+                            // show each error message in a notification
+                            foreach ($errorMessages as $errorMessage) {
+                                $i++;
+
+                                Notification::make('xlsform_template_language_validation_failed_' . $i)
+                                    ->title('XLSForm Template language validation failed')
+                                    ->body('Error: '. $errorMessage)
+                                    ->danger()
+                                    ->persistent()
+                                    ->send();
+                            }
+
+                            // fail the wizard step, keep user in step 1
+                            throw new Halt();
+                        }
 
 
                         // wait to trigger the saved event until the xlsform file is attached.
@@ -104,9 +125,15 @@ class CreateXlsformTemplate extends CreateRecord
                         return redirect($this->getResource()::getUrl('edit', ['record' => $xlsformTemplate]));
                     } catch (\Throwable $e) {
 
+                        $notificationBody = 'There was an error saving the XLSForm Template. ODK Returned the following error: ' . $e->getMessage();
+
+                        if ($e->getMessage() == '') {
+                            $notificationBody = 'There was an error saving the XLSForm Template. Please refer to validation error message in other notification(s) for correction then try again.';
+                        }
+
                         Notification::make('xlsform_template_not_saved')
                             ->title('XLSForm Template Not Saved')
-                            ->body('There was an error saving the XLSForm Template. ODK Returned the following error: '.$e->getMessage())
+                            ->body($notificationBody)
                             ->danger()
                             ->persistent()
                             ->send();

--- a/src/Services/XlsformValidationHelper.php
+++ b/src/Services/XlsformValidationHelper.php
@@ -9,12 +9,12 @@ use Stats4sd\FilamentOdkLink\Imports\XlsformTemplate\XlsformTemplateValidator;
 
 /**
  * 
- * This helper class aims to contain business logic to validate the uploaded xlsform template excel file before sending it to test on ODK central.
+ * This helper class aims to centralise business logic to validate the uploaded xlsform template excel file before sending it to test on ODK central.
  * It includes below customised validations. More validations will be added from time to time.
  * 
  * Customised validations:
  * 1. ODK variable with type "or_other"
- * 2. language string column header without language or with a non-existed language (TODO)
+ * 2. Language string column header without a defined language (without a language or with a non-existed language)
  * 
  */
 class XlsformValidationHelper
@@ -24,6 +24,7 @@ class XlsformValidationHelper
      * 
      * ODK central does not recommend to use "or_other" as it does not support multiple languages.
      * It is advised to manually add an "Other" option to choices list. Then use a follow-up text question that is only relevant if "Other" is selected'
+     * 
      * 
      * Input parameters:
      *  - pathName is the full file path of the uploaded xlsform template excel file
@@ -49,6 +50,89 @@ class XlsformValidationHelper
                 break;
             }
         }
+
+        return $result;
+    }
+
+
+    /**
+     * A validation to check if the uploaded xlsform template excel file contains any column header without language or with a non-existed language.
+     * 
+     * For header columns starts with any language string type (defined in language_string_types table):
+     * e.g. label, hint, relevant_message, required_message, constraint_message, guidance_hint, mediaimage, mdeiaaudio, mediavideo, image, audio, video
+     * 
+     * These header columns should contain a two chars language code inside (), e.g. (en), (fr), (es)
+     * 
+     * A validation error should be showed if a header column without a two chars language code, or the language code is not existed in application.
+     * 
+     * Assumptions:
+     * 1. The column headers are in pre-defined format. e.g. label::English (en), label::French (fr)
+     * 2. If there is a new column header like label^^English___en, it will pass this validation but this column is assumed not to be handled in ODK central.
+     * 3. For simplicity, only column header prefix and column header postfix will be checked by string comparison. Regular expression will not be used.
+     * 4. Column header prefix will be checked for language string type, column header postfix will be checked for two chars language code
+     * 
+     * 
+     * Input parameters:
+     *  - pathName is the full file path of the uploaded xlsform template excel file
+     * 
+     * Output parameters:
+     *  - a collection of error messages
+     * 
+     */
+    public static function validateColumnHeadersWithLanguageString($pathName): Collection {
+        // initialise error messages collection
+        $result = collect();
+
+        // get language string types and languages from XlsformTranslationHelper
+        $xlsformTranslationHelper = new XlsformTranslationHelper;
+        $languageStringTypes = $xlsformTranslationHelper->languageStringTypes;
+        $languages = $xlsformTranslationHelper->languages;
+
+        // convert the uploaded excel file into a collection
+        $collection = Excel::toCollection(new XlsformTemplateValidator(), $pathName);
+
+        // XlsformTemplateValidator returns survey excel sheet and choices excel sheet only, check all items in the returned collection
+        foreach ($collection as $sheet) {
+            // each item is an associative array with column header as key, only get the first item from excel sheet is good enough
+            $firstRow = $sheet->first();
+
+            // get all keys (i.e. column headers) from associative array
+            $columnHeaders = array_keys($firstRow->toArray());
+
+            // check if a column header belongs to a language string type
+            foreach ($columnHeaders as $columnHeader) {
+                $isLanguageStringType = false;
+
+                foreach ($languageStringTypes as $languageStringType) {
+                    if (Str::startsWith($columnHeader, $languageStringType->name)) {
+                        $isLanguageStringType = true;
+                        break;
+                    }
+                }
+
+                // if this column header is a language string type, check language code 
+                if ($isLanguageStringType == true) {
+                    $hasLanguageCode = false;
+
+                    // if a column header belongs to a language string type, check if a column header contains a two chars language
+                    foreach ($languages as $language) {
+                        if (Str::endsWith($columnHeader, '_' . $language->iso_alpha2)) {
+                            $hasLanguageCode = true;
+                            break;
+                        }
+                    }
+                
+                    // if column header is a language string type, but without language code, add error message
+                    if (!$hasLanguageCode) {
+                        // Note: after loading excel file into collection, column header does not appear exactly the same in xlsform template excel file
+                        $result->add('Column header "' . $columnHeader . '" does not have a defined language code.');
+                    }
+
+                }
+
+            } // end foreach column header
+            
+        } // end foreach excel sheet
 
         return $result;
     }


### PR DESCRIPTION
This PR is submitted to fix https://github.com/stats4sd/filament-odk-link/issues/59 and https://github.com/stats4sd/apni-research/issues/38

It is now ready for review.

---

It contains below changes:
 - [x] add custom validation to check if column headers with defined language, show validation errors if no language defined or non-existed language defined
 - [x] a minor refinement on error message of the original notification. This is now asking user to refer to the validation error message in notification(s)

---

Screen shots:

<img width="1920" height="982" alt="Screenshot from 2025-07-23 22-16-41" src="https://github.com/user-attachments/assets/8c72d9c9-a8a8-4768-b338-f6634657a5df" />
