### PR TITLE
Add Module Builder

### DIFF
--- a/src/Filament/OdkAdmin/Resources/LocalIndicatorResource.php
+++ b/src/Filament/OdkAdmin/Resources/LocalIndicatorResource.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources;
+
+use Filament\Forms;
+use Filament\Tables;
+use Filament\Forms\Form;
+use Filament\Tables\Table;
+use Filament\Resources\Resource;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\LocalIndicator;
+use Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource\Pages;
+use Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource\RelationManagers;
+
+class LocalIndicatorResource extends Resource
+{
+    protected static ?string $model = LocalIndicator::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    // change page title by changing label
+    protected static ?string $label = 'Custom Module';
+
+    // change navigation label
+    protected static ?string $navigationLabel = 'Custom Module';
+
+    protected static ?string $navigationGroup = 'Custom Module';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Hidden::make('team_id')
+                    ->required()
+                    ->default(auth()->user()->latestTeam->id),
+                Forms\Components\TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                // TODO: remove domain_id when tidying table local_indicators
+                Forms\Components\Hidden::make('domain_id')
+                    ->default(1)
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable(),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListLocalIndicators::route('/'),
+            'create' => Pages\CreateLocalIndicator::route('/create'),
+            'edit' => Pages\EditLocalIndicator::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/OdkAdmin/Resources/LocalIndicatorResource.php
+++ b/src/Filament/OdkAdmin/Resources/LocalIndicatorResource.php
@@ -19,13 +19,7 @@ class LocalIndicatorResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
 
-    // change page title by changing label
-    protected static ?string $label = 'Custom Module';
-
-    // change navigation label
-    protected static ?string $navigationLabel = 'Custom Module';
-
-    protected static ?string $navigationGroup = 'Custom Module';
+    protected static ?string $navigationGroup = 'Module Builder';
 
     public static function form(Form $form): Form
     {

--- a/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/CreateLocalIndicator.php
+++ b/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/CreateLocalIndicator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateLocalIndicator extends CreateRecord
+{
+    protected static string $resource = LocalIndicatorResource::class;
+
+
+    protected function getRedirectUrl(): string
+    {
+        return LocalIndicatorResource::getUrl('index');
+    }
+}

--- a/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/EditLocalIndicator.php
+++ b/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/EditLocalIndicator.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditLocalIndicator extends EditRecord
+{
+    protected static string $resource = LocalIndicatorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+
+
+    protected function getRedirectUrl(): string
+    {
+        return LocalIndicatorResource::getUrl('index');
+    }
+}

--- a/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/ListLocalIndicators.php
+++ b/src/Filament/OdkAdmin/Resources/LocalIndicatorResource/Pages/ListLocalIndicators.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource\Pages;
+
+use Stats4sd\FilamentOdkLink\Filament\OdkAdmin\Resources\LocalIndicatorResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListLocalIndicators extends ListRecords
+{
+    protected static string $resource = LocalIndicatorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/src/Models/OdkLink/LocalIndicator.php
+++ b/src/Models/OdkLink/LocalIndicator.php
@@ -1,0 +1,57 @@
+<?php
+
+// namespace App\Models\Holpa;
+namespace Stats4sd\FilamentOdkLink\Models\OdkLink;
+
+use App\Models\Team;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
+
+// keep model name as LocalIndicator temporary. It is easier and trace in early stage.
+// This class will be renamed as CustomModule in later stage
+class LocalIndicator extends Model
+{
+    use HasFactory;
+
+    protected $table = 'local_indicators';
+
+    protected $guarded = ['id'];
+
+    protected static function booted()
+    {
+        static::created(function (self $localIndicator) {
+            $xlsformModuleVersion = $localIndicator->xlsformModuleVersion()->create([
+                'owner_id' => $localIndicator->team_id,
+                'name' => $localIndicator->name,
+                'is_default' => false,
+            ]);
+
+            // I have no idea why the above doesn't automatically associate the new module version with the current local indicator...
+            $localIndicator->xlsformModuleVersion()->associate($xlsformModuleVersion);
+            $localIndicator->save();
+        });
+    }
+
+    // public function domain(): BelongsTo
+    // {
+    //     return $this->belongsTo(Domain::class);
+    // }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    // public function globalIndicator(): BelongsTo
+    // {
+    //     return $this->belongsTo(GlobalIndicator::class);
+    // }
+
+    public function xlsformModuleVersion(): BelongsTo
+    {
+        return $this->belongsTo(XlsformModuleVersion::class);
+    }
+
+}


### PR DESCRIPTION
This PR is submitted to add module builder.

It should have below similar functionalities in HOLPA Localisation: LISP section:
1. Maintain local indicator (it will be renamed to custom module later on)
2. For each local indicator, main custom questions
3. Allow user to select standard modules (e.g. location, consent, end of survey, etc) and custom module. To form a new customised ODK form

---

Initial idea:
1. Copy local indicator model from HOLPA main repo to submodule filament-odk-link
2. Add filament resource for local indicator in Admin panel
3. Add relation manager to maintain custom questions for each local indicator
4. Add filament resource to construct a new ODK form with standard modules and custom modules

---

Screen shots:

<img width="1920" height="982" alt="image" src="https://github.com/user-attachments/assets/57d958d1-1ca0-4759-8f95-6692a565f225" />

<img width="1920" height="982" alt="image" src="https://github.com/user-attachments/assets/7810c91c-ed4a-40d8-86d7-de8849a33cbd" />

