### PR TITLE
Add Module Builder

### DIFF
--- a/src/Filament/OdkAdmin/Resources/XlsformModuleVersionResource.php
+++ b/src/Filament/OdkAdmin/Resources/XlsformModuleVersionResource.php
@@ -25,10 +25,11 @@ class XlsformModuleVersionResource extends Resource
         return $form
             ->columns(1)
             ->schema([
+                // change xlsform_module_id from required to optional.
+                // This allows to create a new xlsform module version without linking it to any existing xlsform module
                 Forms\Components\Select::make('xlsform_module_id')
                     ->relationship('xlsformModule', 'label')
-                    ->getOptionLabelFromRecordUsing(fn (XlsformModule $xlsformModule): string => "{$xlsformModule->xlsformTemplate->title} - $xlsformModule->name")
-                    ->required(),
+                    ->getOptionLabelFromRecordUsing(fn (XlsformModule $xlsformModule): string => "{$xlsformModule->xlsformTemplate->title} - $xlsformModule->name"),
                 Forms\Components\TextInput::make('name')
                     ->required()
                     ->maxLength(255),


### PR DESCRIPTION
This PR is submitted to add module builder.

It needs to be reviewed together with groundswell_platform PR 23 https://github.com/stats4sd/groundswell_platform/pull/23

It is to allow Super Admin user to create new Xlsform Module Version record without linking to any existing Xlsform Module.

---

It contains below changes:
 - [x] Xlsform Module Version resource, change xlsform module from required to optional when creating a new xlsform module version

