### PR TITLE
Location Minor Fix Submodule

### DIFF
--- a/database/migrations/004_create_xlsform_module_versions_table.php
+++ b/database/migrations/004_create_xlsform_module_versions_table.php
@@ -26,7 +26,7 @@ return new class extends Migration
 
             $table->timestamps();
 
-            $table->unique(['xlsform_module_id', 'name']);
+            $table->unique(['xlsform_module_id', 'owner_id', 'name']);
         });
     }
 


### PR DESCRIPTION
This PR is submitted to fix issue during testing cross-team location scoping issue.

In xlsform_module_versions table, we have a unique key for xlsform_module_id and name.

We need to include column owner_id in this unique key, so that we can have multiple "Local locations" records with same xlsform_module_id and name, but different owner_id.

---

It contains below changes:
 - [x] xlsform_module_versions table, include owner_id to unique key for xlsform_module_id and name