### PR TITLE
Add job failure notifications and processing-flag resets; remove dead…

### DIFF
--- a/database/migrations/001_create_xlsform_templates_table.php
+++ b/database/migrations/001_create_xlsform_templates_table.php
@@ -26,7 +26,6 @@ return new class extends Migration
             $table->string('enketo_draft_id')->nullable()->comment('id component of the enketo version - pulled from the ODK service if supported/enabled');
             $table->boolean('draft_needs_update')->default(0)->comment('Set to true if the form has been updated since the last draft was deployed to ODK Central');
             $table->timestamp('odk_draft_updated_at')->nullable();
-            $table->text('odk_error')->nullable()->comment('If a xlsfile upload results in an ODK syntax error, it will be stored here. For working forms, this will be null');
             $table->string('odk_version_id')->nullable();
 
             // The full schema of the form, as a json object

--- a/database/migrations/002_create_xlsforms_table.php
+++ b/database/migrations/002_create_xlsforms_table.php
@@ -37,7 +37,6 @@ return new class extends Migration {
 
             // Processing
             $table->boolean('processing')->default(0)->comment('Is the form currently being processed? (helps to avoid duplicate deployments)');
-            $table->text('odk_error')->nullable()->comment('If an xlsfile upload returns an error from the ODK Aggregate service, it will be stored here');
 
             // The full schema of the form, as a json object
             $table->json('schema')->nullable();

--- a/database/migrations/010_create_submissions_table.php
+++ b/database/migrations/010_create_submissions_table.php
@@ -20,11 +20,6 @@ return new class extends Migration {
             $table->string('submitted_by')->nullable();
             $table->string('updated_by')->nullable();
             $table->longtext('content'); // This is explicitly not json so the ordering of variables is preserved (at the expense of not being able to query the content in SQL);
-            $table->json('errors')->nullable();
-            $table->boolean('processed')->default(0);
-
-            // what data model entries were created when processing this submission? (e.g., if the application has custom data maps that populate tables from processed submissions.
-            $table->json('entries')->nullable();
 
             $table->boolean('draft_data')->default(0);
             $table->boolean('test_data')->default(0);

--- a/src/Concerns/NotifiesOnJobFailure.php
+++ b/src/Concerns/NotifiesOnJobFailure.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Concerns;
+
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Role;
+use Throwable;
+
+trait NotifiesOnJobFailure
+{
+    /**
+     * @param  Model|Authenticatable|Collection<int, Model|Authenticatable>|array<int, Model|Authenticatable>  $recipients
+     */
+    public function notifyJobFailure(string $title, ?Throwable $exception, Model|Authenticatable|Collection|array $recipients, ?string $actionUrl = null): void
+    {
+        $notification = Notification::make()
+            ->title($title)
+            ->body(Str::limit($exception?->getMessage() ?? 'Unknown error', 200))
+            ->danger()
+            ->persistent();
+
+        if ($actionUrl) {
+            $notification->actions([
+                Action::make('view')->url($actionUrl),
+            ]);
+        }
+
+        foreach ($this->normaliseRecipients($recipients) as $recipient) {
+            $notification
+                ->sendToDatabase($recipient, isEventDispatched: true)
+                ->broadcast($recipient);
+        }
+    }
+
+    /** @return Collection<int, Model> */
+    public function superAdmins(): Collection
+    {
+        $superAdminRole = Role::where('name', 'Super Admin')->first();
+
+        if (! $superAdminRole) {
+            return new Collection;
+        }
+
+        return $superAdminRole->users;
+    }
+
+    /**
+     * @param  Model|Authenticatable|Collection<int, Model|Authenticatable>|array<int, Model|Authenticatable>  $recipients
+     * @return Collection<int, Model|Authenticatable>
+     */
+    private function normaliseRecipients(Model|Authenticatable|Collection|array $recipients): Collection
+    {
+        if ($recipients instanceof Collection) {
+            return $recipients;
+        }
+
+        if (is_array($recipients)) {
+            return collect($recipients);
+        }
+
+        return collect([$recipients]);
+    }
+}

--- a/src/Concerns/ResetsProcessingOnFailure.php
+++ b/src/Concerns/ResetsProcessingOnFailure.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Stats4sd\FilamentOdkLink\Concerns;
+
+use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Throwable;
+
+/**
+ * Failure hook for the template-import chain jobs. Each job holds the model being
+ * imported as a public $model property (XlsformTemplate or XlsformModuleVersion);
+ * on failure the `processing` flag is cleared so the template is not stuck, and
+ * Super Admins get a durable notification.
+ */
+trait ResetsProcessingOnFailure
+{
+    use NotifiesOnJobFailure;
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $this->model->updateQuietly(['processing' => false]);
+
+        $title = $this->model instanceof XlsformTemplate
+            ? "Xlsform template import failed: {$this->model->title}"
+            : "Module questions import failed: {$this->model->name}";
+
+        $this->notifyJobFailure($title, $exception, $this->superAdmins());
+    }
+}

--- a/src/Exports/XlsformExport/XlsformWorkbookExport.php
+++ b/src/Exports/XlsformExport/XlsformWorkbookExport.php
@@ -2,15 +2,19 @@
 
 namespace Stats4sd\FilamentOdkLink\Exports\XlsformExport;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
+use Throwable;
 
 
 class XlsformWorkbookExport implements WithMultipleSheets, ShouldQueue
 {
+    use NotifiesOnJobFailure;
 
-    public function __construct(public Xlsform $xlsform)
+    public function __construct(public Xlsform $xlsform, public ?Authenticatable $user = null)
     {
     }
 
@@ -27,5 +31,16 @@ class XlsformWorkbookExport implements WithMultipleSheets, ShouldQueue
         }
 
         return $sheets;
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $this->xlsform->updateQuietly(['processing' => false]);
+
+        $this->notifyJobFailure(
+            "Form file generation failed: {$this->xlsform->title}",
+            $exception,
+            $this->user ?? $this->superAdmins(),
+        );
     }
 }

--- a/src/Imports/XlsformTemplate/XlsformTemplateChoiceListImport.php
+++ b/src/Imports/XlsformTemplate/XlsformTemplateChoiceListImport.php
@@ -8,18 +8,24 @@ use Maatwebsite\Excel\Concerns\Importable;
 use Maatwebsite\Excel\Concerns\SkipsEmptyRows;
 use Maatwebsite\Excel\Concerns\ToModel;
 use Maatwebsite\Excel\Concerns\WithChunkReading;
+use Maatwebsite\Excel\Concerns\RegistersEventListeners;
+use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithHeadingRow;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Concerns\WithUpserts;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
+use Throwable;
 
-class XlsformTemplateChoiceListImport implements ShouldQueue, SkipsEmptyRows, ToModel, WithChunkReading, WithHeadingRow, WithMultipleSheets, WithUpserts
+class XlsformTemplateChoiceListImport implements ShouldQueue, SkipsEmptyRows, ToModel, WithChunkReading, WithEvents, WithHeadingRow, WithMultipleSheets, WithUpserts
 {
     use GetsModuleNamesPerRow;
     use Importable;
+    use NotifiesOnJobFailure;
+    use RegistersEventListeners;
 
     /**
      * @throws \Exception
@@ -111,5 +117,18 @@ class XlsformTemplateChoiceListImport implements ShouldQueue, SkipsEmptyRows, To
     public function batchSize(): int
     {
         return 1000;
+    }
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $label = $this->model instanceof XlsformTemplate
+            ? $this->model->title
+            : $this->model->name;
+
+        $this->notifyJobFailure(
+            "Choice list import failed: {$label}",
+            $exception,
+            $this->superAdmins(),
+        );
     }
 }

--- a/src/Imports/XlsformTemplate/XlsformTemplateWorkbookImport.php
+++ b/src/Imports/XlsformTemplate/XlsformTemplateWorkbookImport.php
@@ -10,6 +10,7 @@ use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithEvents;
 use Maatwebsite\Excel\Concerns\WithMultipleSheets;
 use Maatwebsite\Excel\Events\AfterImport;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceListEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\SurveyRow;
@@ -20,6 +21,7 @@ class XlsformTemplateWorkbookImport implements WithMultipleSheets, ShouldQueue, 
 {
 
     use RegistersEventListeners;
+    use ResetsProcessingOnFailure;
     use Importable;
 
     public function __construct(public XlsformModuleVersion | XlsformTemplate $model, public Collection $translatableHeadings, public string $moduleColumn = 'module')

--- a/src/Jobs/AddMissingChoiceListStrings.php
+++ b/src/Jobs/AddMissingChoiceListStrings.php
@@ -5,6 +5,7 @@ namespace Stats4sd\FilamentOdkLink\Jobs;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceListEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\LanguageString;
@@ -15,6 +16,7 @@ use Stats4sd\FilamentOdkLink\Services\XlsformTranslationHelper;
 class AddMissingChoiceListStrings implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
 
     public function __construct(public XlsformModuleVersion|XlsformTemplate $model)

--- a/src/Jobs/FinishChoiceListEntryImport.php
+++ b/src/Jobs/FinishChoiceListEntryImport.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Str;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceListEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\RequiredMedia;
@@ -15,6 +16,7 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 class FinishChoiceListEntryImport implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     public function __construct(public XlsformModuleVersion|XlsformTemplate $model)
     {

--- a/src/Jobs/FinishLanguageStringImport.php
+++ b/src/Jobs/FinishLanguageStringImport.php
@@ -5,6 +5,7 @@ namespace Stats4sd\FilamentOdkLink\Jobs;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Queue\Queueable;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceList;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\ChoiceListEntry;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\LanguageString;
@@ -15,6 +16,7 @@ use Stats4sd\FilamentOdkLink\Services\XlsformTranslationHelper;
 class FinishLanguageStringImport implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
 
     public function __construct(public XlsformModuleVersion|XlsformTemplate $model, public string $heading)

--- a/src/Jobs/FinishSurveyRowImport.php
+++ b/src/Jobs/FinishSurveyRowImport.php
@@ -4,6 +4,7 @@ namespace Stats4sd\FilamentOdkLink\Jobs;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Exports\XlsformTemplateTranslationsExport;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
@@ -11,6 +12,7 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 class FinishSurveyRowImport implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     public function __construct(public XlsformModuleVersion | XlsformTemplate $model)
     {

--- a/src/Jobs/FinishXlsformTemplateImport.php
+++ b/src/Jobs/FinishXlsformTemplateImport.php
@@ -8,6 +8,7 @@ use Filament\Notifications\Notification;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Spatie\Permission\Models\Role;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Exports\XlsformTemplateTranslationsExport;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
@@ -16,6 +17,7 @@ use Stats4sd\FilamentTeamManagement\Models\User;
 class FinishXlsformTemplateImport implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     public function __construct(public XlsformModuleVersion|XlsformTemplate $model)
     {

--- a/src/Jobs/ImportAllLanguageStrings.php
+++ b/src/Jobs/ImportAllLanguageStrings.php
@@ -7,6 +7,7 @@ use App\Services\HelperService;
 use Illuminate\Support\Collection;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
 use Stats4sd\FilamentOdkLink\Imports\XlsformTemplate\XlsformTemplateLanguageStringImport;
@@ -14,6 +15,7 @@ use Stats4sd\FilamentOdkLink\Imports\XlsformTemplate\XlsformTemplateLanguageStri
 class ImportAllLanguageStrings implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     /**
      * Create a new job instance.

--- a/src/Jobs/LinkModuleVersionToLocales.php
+++ b/src/Jobs/LinkModuleVersionToLocales.php
@@ -5,6 +5,7 @@ namespace Stats4sd\FilamentOdkLink\Jobs;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Collection;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformLanguages\Language;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformLanguages\Locale;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModule;
@@ -15,6 +16,7 @@ use Stats4sd\FilamentOdkLink\Services\XlsformTranslationHelper;
 class LinkModuleVersionToLocales implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     /** @var Collection<Language> */
     public Collection $languages;

--- a/src/Jobs/OdkSubmissions/ProcessOdkSubmission.php
+++ b/src/Jobs/OdkSubmissions/ProcessOdkSubmission.php
@@ -4,12 +4,15 @@ namespace Stats4sd\FilamentOdkLink\Jobs\OdkSubmissions;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Submission;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformVersion;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Throwable;
 
 class ProcessOdkSubmission implements ShouldQueue
 {
+    use NotifiesOnJobFailure;
     use Queueable;
 
     public function __construct(public Submission $submission, public array $entry, public XlsformVersion $xlsformVersion)
@@ -33,5 +36,16 @@ class ProcessOdkSubmission implements ShouldQueue
             $class::$method($this->submission);
         }
 
+    }
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $formTitle = $this->submission->xlsform->title ?? 'unknown form';
+
+        $this->notifyJobFailure(
+            "Submission processing failed: {$this->submission->odk_id} ({$formTitle})",
+            $exception,
+            $this->superAdmins(),
+        );
     }
 }

--- a/src/Jobs/PrepareSurveyRowPaths.php
+++ b/src/Jobs/PrepareSurveyRowPaths.php
@@ -5,6 +5,7 @@ namespace Stats4sd\FilamentOdkLink\Jobs;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\Eloquent\Collection;
+use Stats4sd\FilamentOdkLink\Concerns\ResetsProcessingOnFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\SurveyRow;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformModuleVersion;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
@@ -12,6 +13,7 @@ use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 class PrepareSurveyRowPaths implements ShouldQueue
 {
     use Queueable;
+    use ResetsProcessingOnFailure;
 
     /**
      * Create a new job instance.

--- a/src/Jobs/PullSubmissionsFromXlsform.php
+++ b/src/Jobs/PullSubmissionsFromXlsform.php
@@ -7,13 +7,16 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Throwable;
 
 class PullSubmissionsFromXlsform implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
+    use NotifiesOnJobFailure;
     use Queueable;
     use SerializesModels;
 
@@ -33,5 +36,14 @@ class PullSubmissionsFromXlsform implements ShouldQueue
         $odkLinkService = app()->make(OdkLinkService::class);
 
         $odkLinkService->getSubmissions($this->xlsform);
+    }
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $this->notifyJobFailure(
+            "Submission pull failed: {$this->xlsform->title} ({$this->xlsform->owner->name})",
+            $exception,
+            $this->superAdmins(),
+        );
     }
 }

--- a/src/Jobs/PullSubmissionsFromXlsformQuietly.php
+++ b/src/Jobs/PullSubmissionsFromXlsformQuietly.php
@@ -3,14 +3,17 @@
 namespace Stats4sd\FilamentOdkLink\Jobs;
 
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Http;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Throwable;
 
 /**
  * Temporary Job to pull submissions from an Xlsform without running any additional processing (for testing)
@@ -20,6 +23,7 @@ class PullSubmissionsFromXlsformQuietly implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
+    use NotifiesOnJobFailure;
     use Queueable;
     use SerializesModels;
 
@@ -63,7 +67,7 @@ class PullSubmissionsFromXlsformQuietly implements ShouldQueue
                     'ownerName' => $this->xlsform->owner->name,
                 ]);
 
-                abort(500, 'The system tried to get submission data for a form version that does not exist.  Please copy the following details and send them to the system administrator: ' . $messageContent->map(fn ($item, $key) => "$key: $item")->implode(', '));
+                throw new Exception('The system tried to get submission data for a form version that does not exist.  Please copy the following details and send them to the system administrator: ' . $messageContent->map(fn ($item, $key) => "$key: $item")->implode(', '));
             }
 
             // Question: For column submission.content, should we store the original $entry instead of the return value of processEntry()?
@@ -74,5 +78,14 @@ class PullSubmissionsFromXlsformQuietly implements ShouldQueue
                 'content' => $entry,
             ]);
         }
+    }
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $this->notifyJobFailure(
+            "Submission pull failed: {$this->xlsform->title} ({$this->xlsform->owner->name})",
+            $exception,
+            $this->superAdmins(),
+        );
     }
 }

--- a/src/Jobs/XlsformDeployment/DeployDraftXlsformToOdkCentral.php
+++ b/src/Jobs/XlsformDeployment/DeployDraftXlsformToOdkCentral.php
@@ -9,6 +9,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Exceptions\OdkCentralRequestException;
 use Stats4sd\FilamentOdkLink\Exceptions\XlsformValidationException;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
@@ -18,6 +19,7 @@ use Throwable;
 
 class DeployDraftXlsformToOdkCentral implements ShouldQueue
 {
+    use NotifiesOnJobFailure;
     use Queueable;
 
     public int $tries = 3;
@@ -107,18 +109,25 @@ class DeployDraftXlsformToOdkCentral implements ShouldQueue
             'exception' => $exception,
         ]);
 
-        if (! $this->user) {
-            return;
-        }
+        $this->xlsform->updateQuietly(['processing' => false]);
 
         $message = $exception?->getMessage() ?? 'No error message was returned. Please check the application logs for details.';
 
-        Notification::make('xlsform_file_deployment_failed')
+        $recipients = $this->user
+            ? collect([$this->user])
+            : $this->superAdmins();
+
+        $notification = Notification::make('xlsform_file_deployment_failed')
             ->title('Draft Form "' . $this->xlsform->title . '" failed to deploy')
             ->body(new HtmlString('The message below was returned from the ODK Server. It may indicate an issue with the Xlsform definition being used: <br/><br/>' . $message))
             ->danger()
-            ->persistent()
-            ->broadcast($this->user);
+            ->persistent();
+
+        foreach ($recipients as $recipient) {
+            $notification
+                ->sendToDatabase($recipient, isEventDispatched: true)
+                ->broadcast($recipient);
+        }
     }
 
     /**

--- a/src/Jobs/XlsformDeployment/PublishXlsformOnOdkCentral.php
+++ b/src/Jobs/XlsformDeployment/PublishXlsformOnOdkCentral.php
@@ -2,25 +2,27 @@
 
 namespace Stats4sd\FilamentOdkLink\Jobs\XlsformDeployment;
 
-use Carbon\Carbon;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\HtmlString;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Abstracts\HasXlsformDrafts;
-use Stats4sd\FilamentOdkLink\Models\OdkLink\Interfaces\WithXlsformDrafts;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\XlsformTemplate;
 use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Throwable;
-use function Laravel\Prompts\search;
 
 class PublishXlsformOnOdkCentral implements ShouldQueue
 {
+    use NotifiesOnJobFailure;
     use Queueable;
+
+    public int $tries = 3;
+
+    /** @var array<int, int> */
+    public array $backoff = [15, 60];
 
     public function __construct(public Xlsform|XlsformTemplate $xlsform, public ?Authenticatable $user)
     {
@@ -48,13 +50,24 @@ class PublishXlsformOnOdkCentral implements ShouldQueue
     {
         Log::error('Xlsform Publishing Failed', ['exception' => $exception]);
 
-        if ($this->user) {
-            Notification::make('xlsform_file_deployment_failed')
-                ->title('Form "'.$this->xlsform->title.'" failed to publish')
-                ->body(new HtmlString('The message below was returned from the ODK Server. It may indicate an issue with the Xlsform definition being used: <br/><br/>' . $exception->getmessage()))
-                ->danger()
-                ->persistent()
-                ->broadcast($this->user);
+        $this->xlsform->updateQuietly(['processing' => false]);
+
+        $message = $exception?->getMessage() ?? 'No error message was returned. Please check the application logs for details.';
+
+        $recipients = $this->user
+            ? collect([$this->user])
+            : $this->superAdmins();
+
+        $notification = Notification::make('xlsform_file_deployment_failed')
+            ->title('Form "' . $this->xlsform->title . '" failed to publish')
+            ->body(new HtmlString('The message below was returned from the ODK Server. It may indicate an issue with the Xlsform definition being used: <br/><br/>' . $message))
+            ->danger()
+            ->persistent();
+
+        foreach ($recipients as $recipient) {
+            $notification
+                ->sendToDatabase($recipient, isEventDispatched: true)
+                ->broadcast($recipient);
         }
     }
 }

--- a/src/Jobs/XlsformDeployment/UpdateXlsformFile.php
+++ b/src/Jobs/XlsformDeployment/UpdateXlsformFile.php
@@ -2,19 +2,22 @@
 
 namespace Stats4sd\FilamentOdkLink\Jobs\XlsformDeployment;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileIsTooBig;
+use Stats4sd\FilamentOdkLink\Concerns\NotifiesOnJobFailure;
 use Stats4sd\FilamentOdkLink\Models\OdkLink\Xlsform;
-use Stats4sd\FilamentOdkLink\Services\OdkLinkService;
+use Throwable;
 
 class UpdateXlsformFile implements ShouldQueue
 {
+    use NotifiesOnJobFailure;
     use Queueable;
 
-    public function __construct(public Xlsform $xlsform, public string $filePath)
+    public function __construct(public Xlsform $xlsform, public string $filePath, public ?Authenticatable $user = null)
     {
     }
 
@@ -25,13 +28,26 @@ class UpdateXlsformFile implements ShouldQueue
     {
         try {
             $this->xlsform->addMediaFromDisk($this->filePath, config('filament-odk-link.storage.xlsforms'))->toMediaCollection('xlsform_file');
-        } catch (FileDoesNotExist $e) {
-            Log::error('Trying to save file for Xlsform '.  $this->xlsform->id . ' that does not exist at path ' . $this->filePath);
-        } catch (FileIsTooBig $e) {
-            Log::error('Trying to save file for Xlsform '.  $this->xlsform->id . ' that is too big at path ' . $this->filePath);
+        } catch (FileDoesNotExist $exception) {
+            Log::error('Trying to save file for Xlsform ' . $this->xlsform->id . ' that does not exist at path ' . $this->filePath);
+            $this->fail($exception);
+        } catch (FileIsTooBig $exception) {
+            Log::error('Trying to save file for Xlsform ' . $this->xlsform->id . ' that is too big at path ' . $this->filePath);
+            $this->fail($exception);
         } finally {
             $this->xlsform->updateQuietly(['processing' => false]);
         }
 
+    }
+
+    public function failed(?Throwable $exception = null): void
+    {
+        $this->xlsform->updateQuietly(['processing' => false]);
+
+        $this->notifyJobFailure(
+            "Form file update failed: {$this->xlsform->title}",
+            $exception,
+            $this->user ?? $this->superAdmins(),
+        );
     }
 }

--- a/src/Listeners/HandleXlsformTemplateAdded.php
+++ b/src/Listeners/HandleXlsformTemplateAdded.php
@@ -2,7 +2,6 @@
 
 namespace Stats4sd\FilamentOdkLink\Listeners;
 
-use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\MediaCollections\Events\MediaHasBeenAddedEvent;
@@ -22,8 +21,6 @@ use Stats4sd\FilamentOdkLink\Services\XlsformTranslationHelper;
 
 class HandleXlsformTemplateAdded
 {
-    public ?User $importedBy = null;
-
     public function handle(MediaHasBeenAddedEvent $event): void
     {
 

--- a/src/Models/OdkLink/Submission.php
+++ b/src/Models/OdkLink/Submission.php
@@ -36,8 +36,6 @@ class Submission extends Model implements HasMedia
 
     protected $casts = [
         'content' => 'array',
-        'errors' => 'array',
-        'entries' => 'array',
         'draft_data' => 'boolean',
         'test_data' => 'boolean',
     ];
@@ -113,22 +111,6 @@ class Submission extends Model implements HasMedia
     public function parent(): BelongsToThrough
     {
         return $this->belongsToThrough();
-    }
-
-// $this->entries is an array of every Model entry created as a result of processing this submission.
-// This helper function makes it easy to update this array.
-    public function addEntry(string $model, array $ids): void
-    {
-        $value = $this->entries;
-
-        if ($value && array_key_exists($model, $value)) {
-            $value[$model] = array_merge($value[$model], $ids);
-        } else {
-            $value[$model] = $ids;
-        }
-
-        $this->entries = $value;
-        $this->save();
     }
 
     /** @return BelongsTo<XlsformVersion, $this> */

--- a/src/Models/OdkLink/Xlsform.php
+++ b/src/Models/OdkLink/Xlsform.php
@@ -11,8 +11,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Filament\Notifications\Notification;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Log;
 use Maatwebsite\Excel\Facades\Excel;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Exceptions\FileDoesNotExist;
@@ -402,9 +404,9 @@ class Xlsform extends HasXlsformDrafts implements HasMedia
         $filePath = 'temp/' . $this->getKey() . '/' . $this->title . '.xlsx';
         $user = auth()->user();
 
-        return Excel::queue(new XlsformWorkbookExport($this), $filePath, config('filament-odk-link.storage.xlsforms'))->chain(
+        return Excel::queue(new XlsformWorkbookExport($this, $user), $filePath, config('filament-odk-link.storage.xlsforms'))->chain(
             [
-                new UpdateXlsformFile($this, $filePath),
+                new UpdateXlsformFile($this, $filePath, $user),
             ]
         );
 
@@ -445,10 +447,27 @@ class Xlsform extends HasXlsformDrafts implements HasMedia
         }
 
         if ($this->draft_needs_update) {
-            return $this->deployDraft()
-                ->chain([
-                    new PublishXlsformOnOdkCentral($this, auth()->user()),
-                ]);
+            $user = auth()->user();
+            $deployment = $this->deployDraft();
+
+            if (! $deployment) {
+                Log::warning("Publishing skipped for xlsform {$this->id}: the draft deployment could not be queued because the form is already processing.");
+
+                if ($user) {
+                    Notification::make()
+                        ->title('Form "' . $this->title . '" could not be published')
+                        ->body('The form is currently being processed. Please wait for the current process to finish and try again.')
+                        ->danger()
+                        ->sendToDatabase($user, isEventDispatched: true)
+                        ->broadcast($user);
+                }
+
+                return null;
+            }
+
+            return $deployment->chain([
+                new PublishXlsformOnOdkCentral($this, $user),
+            ]);
         }
 
         // if no draft update is needed, just publish the form:


### PR DESCRIPTION
… error columns

Every job in the template-import and draft-deployment/publishing chains now has a failed() hook that clears the processing flag and sends a durable (database + broadcast) Filament notification via the new NotifiesOnJobFailure / ResetsProcessingOnFailure concerns. UpdateXlsformFile fails the chain on missing/oversized files instead of continuing silently, publishForm() no longer fatals when deployDraft() returns null, and the submission pull/process jobs notify Super Admins on failure. The never-read odk_error, errors, processed and entries columns are removed from the create-table migrations, along with the Submission casts and addEntry() helper that referenced them.